### PR TITLE
feat(bids): Email quote parsing for manufacturer bids

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { Valuation, ValuationSummary } from './valuation'
 import { InvestorCohorts } from './investors'
 import { AuthProvider, ProtectedRoute, LoginPage, RoleSelector, PermissionGate } from './auth'
 import { SupplierList, SupplierDetail, PurchaseOrderList, PurchaseOrderDetail, Receiving, VendorComparison } from './supply-chain'
+import { BidList, BidDetail } from './bids'
 import { CustomerList, CustomerDetail, QuoteList, QuoteDetail, SalesOrderList, SalesOrderDetail, Fulfillment } from './sales'
 import {
   ProductionDashboard,
@@ -462,6 +463,32 @@ function App() {
                 <PermissionGate permission="view:supply-chain" fallback={<AccessDenied />}>
                   <Layout title="Vendor Comparison">
                     <VendorComparison />
+                  </Layout>
+                </PermissionGate>
+              </ProtectedRoute>
+            }
+          />
+          
+          {/* Bids / Manufacturer Quotes Routes */}
+          <Route
+            path="/bids"
+            element={
+              <ProtectedRoute>
+                <PermissionGate permission="view:supply-chain" fallback={<AccessDenied />}>
+                  <Layout title="Manufacturer Quotes">
+                    <BidList />
+                  </Layout>
+                </PermissionGate>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/bids/:id"
+            element={
+              <ProtectedRoute>
+                <PermissionGate permission="view:supply-chain" fallback={<AccessDenied />}>
+                  <Layout title="Quote Details">
+                    <BidDetail />
                   </Layout>
                 </PermissionGate>
               </ProtectedRoute>

--- a/src/bids/BidDetail.tsx
+++ b/src/bids/BidDetail.tsx
@@ -1,0 +1,511 @@
+/**
+ * @file BidDetail.tsx
+ * @description Detail view for a manufacturer quote with manual correction UI
+ * @related-prd Issue #26 - Email ingestion for manufacturer quotes
+ * @author Ralph (AI Agent)
+ * @created 2026-01-23
+ */
+
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useBidsStore } from './store';
+import type { ParseConfidence, ToolingCost, PaymentTerms } from './types';
+import {
+  BID_STATUS_LABELS,
+  BID_STATUS_COLORS,
+  CONFIDENCE_COLORS,
+  CONFIDENCE_LABELS,
+} from './types';
+
+/**
+ * Editable field component with confidence indicator
+ */
+function EditableField<T>({
+  label,
+  value,
+  confidence,
+  originalText,
+  manuallyEdited,
+  onSave,
+  renderValue,
+  renderInput,
+}: {
+  label: string;
+  value: T | null;
+  confidence: ParseConfidence;
+  originalText: string;
+  manuallyEdited: boolean;
+  onSave: (value: T) => void;
+  // eslint-disable-next-line no-unused-vars
+  renderValue: (value: T | null) => string;
+  renderInput: (
+    // eslint-disable-next-line no-unused-vars
+    value: T | null,
+    // eslint-disable-next-line no-unused-vars
+    onChange: (value: T) => void
+  ) => React.ReactNode;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState<T | null>(value);
+
+  useEffect(() => {
+    setEditValue(value);
+  }, [value]);
+
+  const handleSave = () => {
+    if (editValue !== null) {
+      onSave(editValue);
+    }
+    setIsEditing(false);
+  };
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4">
+      <div className="flex justify-between items-start mb-2">
+        <label className="text-sm font-medium text-gray-700">{label}</label>
+        <div className="flex items-center gap-2">
+          <span className={`text-xs font-medium ${CONFIDENCE_COLORS[confidence]}`}>
+            {manuallyEdited ? '✓ Edited' : CONFIDENCE_LABELS[confidence]}
+          </span>
+        </div>
+      </div>
+
+      {isEditing ? (
+        <div className="space-y-2">
+          {renderInput(editValue, setEditValue as (value: T) => void)}
+          <div className="flex gap-2">
+            <button
+              onClick={handleSave}
+              className="px-3 py-1 bg-blue-600 text-white text-sm rounded hover:bg-blue-700"
+            >
+              Save
+            </button>
+            <button
+              onClick={() => {
+                setEditValue(value);
+                setIsEditing(false);
+              }}
+              className="px-3 py-1 text-gray-600 text-sm hover:text-gray-800"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div
+          onClick={() => setIsEditing(true)}
+          className="cursor-pointer group"
+        >
+          <div className="text-lg font-semibold text-gray-900 group-hover:text-blue-600">
+            {renderValue(value)}
+            <span className="ml-2 text-gray-400 text-sm opacity-0 group-hover:opacity-100">
+              ✎ Edit
+            </span>
+          </div>
+          {originalText && confidence !== 'manual' && (
+            <div className="mt-1 text-xs text-gray-500 italic truncate" title={originalText}>
+              Parsed from: "{originalText}"
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function BidDetail() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const {
+    getQuoteById,
+    updateParsedField,
+    updateQuote,
+    markAsReviewed,
+    acceptQuote,
+    rejectQuote,
+  } = useBidsStore();
+
+  const [rejectReason, setRejectReason] = useState('');
+  const [showRejectModal, setShowRejectModal] = useState(false);
+
+  const quote = id ? getQuoteById(id) : undefined;
+
+  if (!quote) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="text-center">
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">Quote Not Found</h2>
+          <button
+            onClick={() => navigate('/bids')}
+            className="text-blue-600 hover:text-blue-800"
+          >
+            ← Back to Quotes
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const formatCurrency = (value: number | null) => {
+    if (value === null) return 'Not parsed';
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: quote.currency,
+    }).format(value);
+  };
+
+  const handleToolingCostSave = (tooling: ToolingCost) => {
+    updateParsedField<ToolingCost>(quote.id, 'toolingCosts', {
+      ...tooling,
+      total: tooling.moldCost + tooling.setupCost + tooling.otherCosts,
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex justify-between items-start">
+        <div>
+          <button
+            onClick={() => navigate('/bids')}
+            className="text-gray-500 hover:text-gray-700 mb-2 flex items-center gap-1"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            Back to Quotes
+          </button>
+          <h1 className="text-2xl font-bold text-gray-900">{quote.supplierName}</h1>
+          <p className="text-gray-500">{quote.productDescription}</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <span className={`inline-flex px-3 py-1 text-sm font-semibold rounded-full ${BID_STATUS_COLORS[quote.status]}`}>
+            {BID_STATUS_LABELS[quote.status]}
+          </span>
+          {quote.status === 'parsed' && (
+            <button
+              onClick={() => markAsReviewed(quote.id, 'Current User')}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+            >
+              Mark Reviewed
+            </button>
+          )}
+          {quote.status === 'reviewed' && (
+            <>
+              <button
+                onClick={() => acceptQuote(quote.id)}
+                className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700"
+              >
+                Accept Quote
+              </button>
+              <button
+                onClick={() => setShowRejectModal(true)}
+                className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700"
+              >
+                Reject
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Overall Confidence Banner */}
+      {quote.overallConfidence === 'low' && (
+        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+          <div className="flex items-center gap-2">
+            <svg className="w-5 h-5 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+            <span className="text-yellow-800 font-medium">
+              Low parsing confidence – please review and correct the extracted data below.
+            </span>
+          </div>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Parsed Data (Left Column) */}
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold text-gray-900">Extracted Quote Data</h2>
+          <p className="text-sm text-gray-500">Click any field to edit. Changes are marked as manually verified.</p>
+
+          <EditableField
+            label="Unit Cost"
+            value={quote.unitCost.value}
+            confidence={quote.unitCost.confidence}
+            originalText={quote.unitCost.originalText}
+            manuallyEdited={quote.unitCost.manuallyEdited}
+            onSave={(value) => updateParsedField<number>(quote.id, 'unitCost', value)}
+            renderValue={formatCurrency}
+            renderInput={(value, onChange) => (
+              <div className="flex items-center gap-2">
+                <span className="text-gray-500">$</span>
+                <input
+                  type="number"
+                  step="0.01"
+                  value={value ?? ''}
+                  onChange={(e) => onChange(parseFloat(e.target.value))}
+                  className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+            )}
+          />
+
+          <EditableField
+            label="Minimum Order Quantity (MOQ)"
+            value={quote.moq.value}
+            confidence={quote.moq.confidence}
+            originalText={quote.moq.originalText}
+            manuallyEdited={quote.moq.manuallyEdited}
+            onSave={(value) => updateParsedField<number>(quote.id, 'moq', value)}
+            renderValue={(v) => (v ? v.toLocaleString() + ' units' : 'Not parsed')}
+            renderInput={(value, onChange) => (
+              <input
+                type="number"
+                value={value ?? ''}
+                onChange={(e) => onChange(parseInt(e.target.value, 10))}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+              />
+            )}
+          />
+
+          <EditableField
+            label="Lead Time"
+            value={quote.leadTimeDays.value}
+            confidence={quote.leadTimeDays.confidence}
+            originalText={quote.leadTimeDays.originalText}
+            manuallyEdited={quote.leadTimeDays.manuallyEdited}
+            onSave={(value) => updateParsedField<number>(quote.id, 'leadTimeDays', value)}
+            renderValue={(v) => (v ? `${v} days` : 'Not parsed')}
+            renderInput={(value, onChange) => (
+              <div className="flex items-center gap-2">
+                <input
+                  type="number"
+                  value={value ?? ''}
+                  onChange={(e) => onChange(parseInt(e.target.value, 10))}
+                  className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+                />
+                <span className="text-gray-500">days</span>
+              </div>
+            )}
+          />
+
+          <EditableField
+            label="Tooling Costs"
+            value={quote.toolingCosts.value}
+            confidence={quote.toolingCosts.confidence}
+            originalText={quote.toolingCosts.originalText}
+            manuallyEdited={quote.toolingCosts.manuallyEdited}
+            onSave={handleToolingCostSave}
+            renderValue={(v) => {
+              if (!v) return 'Not parsed';
+              return `$${v.total.toLocaleString()} (Mold: $${v.moldCost.toLocaleString()}, Setup: $${v.setupCost.toLocaleString()})`;
+            }}
+            renderInput={(value, onChange) => {
+              const v = value || { moldCost: 0, setupCost: 0, otherCosts: 0, total: 0 };
+              return (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <label className="text-sm text-gray-600 w-20">Mold:</label>
+                    <span className="text-gray-500">$</span>
+                    <input
+                      type="number"
+                      value={v.moldCost}
+                      onChange={(e) => onChange({ ...v, moldCost: parseFloat(e.target.value) || 0 })}
+                      className="flex-1 px-2 py-1 border border-gray-300 rounded"
+                    />
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <label className="text-sm text-gray-600 w-20">Setup:</label>
+                    <span className="text-gray-500">$</span>
+                    <input
+                      type="number"
+                      value={v.setupCost}
+                      onChange={(e) => onChange({ ...v, setupCost: parseFloat(e.target.value) || 0 })}
+                      className="flex-1 px-2 py-1 border border-gray-300 rounded"
+                    />
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <label className="text-sm text-gray-600 w-20">Other:</label>
+                    <span className="text-gray-500">$</span>
+                    <input
+                      type="number"
+                      value={v.otherCosts}
+                      onChange={(e) => onChange({ ...v, otherCosts: parseFloat(e.target.value) || 0 })}
+                      className="flex-1 px-2 py-1 border border-gray-300 rounded"
+                    />
+                  </div>
+                </div>
+              );
+            }}
+          />
+
+          <EditableField
+            label="Payment Terms"
+            value={quote.paymentTerms.value}
+            confidence={quote.paymentTerms.confidence}
+            originalText={quote.paymentTerms.originalText}
+            manuallyEdited={quote.paymentTerms.manuallyEdited}
+            onSave={(value) => updateParsedField<PaymentTerms>(quote.id, 'paymentTerms', value)}
+            renderValue={(v) => v?.type || 'Not parsed'}
+            renderInput={(value, onChange) => {
+              const v = value || { type: '' };
+              return (
+                <div className="space-y-2">
+                  <input
+                    type="text"
+                    value={v.type}
+                    onChange={(e) => onChange({ ...v, type: e.target.value })}
+                    placeholder="e.g., Net 30, 50% deposit"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+                  />
+                  <div className="flex gap-4">
+                    <div className="flex items-center gap-2">
+                      <label className="text-sm text-gray-600">Deposit %:</label>
+                      <input
+                        type="number"
+                        value={v.depositPercent ?? ''}
+                        onChange={(e) => onChange({ ...v, depositPercent: parseInt(e.target.value, 10) || undefined })}
+                        className="w-20 px-2 py-1 border border-gray-300 rounded"
+                      />
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <label className="text-sm text-gray-600">Net Days:</label>
+                      <input
+                        type="number"
+                        value={v.netDays ?? ''}
+                        onChange={(e) => onChange({ ...v, netDays: parseInt(e.target.value, 10) || undefined })}
+                        className="w-20 px-2 py-1 border border-gray-300 rounded"
+                      />
+                    </div>
+                  </div>
+                </div>
+              );
+            }}
+          />
+
+          {/* Notes */}
+          <div className="bg-white rounded-lg border border-gray-200 p-4">
+            <label className="block text-sm font-medium text-gray-700 mb-2">Notes</label>
+            <textarea
+              value={quote.notes}
+              onChange={(e) => updateQuote(quote.id, { notes: e.target.value })}
+              rows={3}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+              placeholder="Add notes about this quote..."
+            />
+          </div>
+        </div>
+
+        {/* Original Email (Right Column) */}
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold text-gray-900">Original Email</h2>
+          <div className="bg-gray-50 rounded-lg border border-gray-200 p-4 space-y-3">
+            <div>
+              <span className="text-sm font-medium text-gray-500">From:</span>
+              <div className="text-gray-900">{quote.emailFrom}</div>
+            </div>
+            <div>
+              <span className="text-sm font-medium text-gray-500">Subject:</span>
+              <div className="text-gray-900">{quote.emailSubject}</div>
+            </div>
+            <div>
+              <span className="text-sm font-medium text-gray-500">Received:</span>
+              <div className="text-gray-900">
+                {new Date(quote.emailReceivedAt).toLocaleString()}
+              </div>
+            </div>
+            <div>
+              <span className="text-sm font-medium text-gray-500">Body:</span>
+              <pre className="mt-2 p-4 bg-white rounded border border-gray-200 text-sm text-gray-800 whitespace-pre-wrap font-mono overflow-auto max-h-96">
+                {quote.emailBody}
+              </pre>
+            </div>
+          </div>
+
+          {/* Metadata */}
+          <div className="bg-white rounded-lg border border-gray-200 p-4 space-y-2">
+            <h3 className="font-medium text-gray-900">Quote Metadata</h3>
+            <div className="grid grid-cols-2 gap-4 text-sm">
+              <div>
+                <span className="text-gray-500">Currency:</span>
+                <span className="ml-2 text-gray-900">{quote.currency}</span>
+              </div>
+              <div>
+                <span className="text-gray-500">Valid Until:</span>
+                <span className="ml-2 text-gray-900">{quote.validUntil || 'Not specified'}</span>
+              </div>
+              <div>
+                <span className="text-gray-500">Created:</span>
+                <span className="ml-2 text-gray-900">
+                  {new Date(quote.createdAt).toLocaleDateString()}
+                </span>
+              </div>
+              <div>
+                <span className="text-gray-500">Last Updated:</span>
+                <span className="ml-2 text-gray-900">
+                  {new Date(quote.updatedAt).toLocaleDateString()}
+                </span>
+              </div>
+              {quote.reviewedBy && (
+                <>
+                  <div>
+                    <span className="text-gray-500">Reviewed By:</span>
+                    <span className="ml-2 text-gray-900">{quote.reviewedBy}</span>
+                  </div>
+                  <div>
+                    <span className="text-gray-500">Reviewed At:</span>
+                    <span className="ml-2 text-gray-900">
+                      {quote.reviewedAt ? new Date(quote.reviewedAt).toLocaleDateString() : '—'}
+                    </span>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Reject Modal */}
+      {showRejectModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg shadow-xl w-full max-w-md mx-4">
+            <div className="px-6 py-4 border-b">
+              <h2 className="text-xl font-semibold text-gray-900">Reject Quote</h2>
+            </div>
+            <div className="px-6 py-4">
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Reason for rejection (optional)
+              </label>
+              <textarea
+                value={rejectReason}
+                onChange={(e) => setRejectReason(e.target.value)}
+                rows={3}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+                placeholder="Price too high, lead time too long, etc."
+              />
+            </div>
+            <div className="flex justify-end gap-3 px-6 py-4 border-t bg-gray-50">
+              <button
+                onClick={() => setShowRejectModal(false)}
+                className="px-4 py-2 text-gray-700 hover:text-gray-900"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => {
+                  rejectQuote(quote.id, rejectReason);
+                  setShowRejectModal(false);
+                  setRejectReason('');
+                }}
+                className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700"
+              >
+                Reject Quote
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/bids/BidList.tsx
+++ b/src/bids/BidList.tsx
@@ -1,0 +1,314 @@
+/**
+ * @file BidList.tsx
+ * @description List view for manufacturer quote bids with filtering and import
+ * @related-prd Issue #26 - Email ingestion for manufacturer quotes
+ * @author Ralph (AI Agent)
+ * @created 2026-01-23
+ */
+
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useBidsStore } from './store';
+import type { BidStatus } from './types';
+import {
+  BID_STATUS_LABELS,
+  BID_STATUS_COLORS,
+  CONFIDENCE_COLORS,
+  CONFIDENCE_LABELS,
+} from './types';
+
+export function BidList() {
+  const navigate = useNavigate();
+  const {
+    getFilteredQuotes,
+    getQuoteStats,
+    filterStatus,
+    setFilterStatus,
+    searchTerm,
+    setSearchTerm,
+    importFromEmail,
+    deleteQuote,
+  } = useBidsStore();
+
+  const [showImportModal, setShowImportModal] = useState(false);
+  const [importEmail, setImportEmail] = useState({
+    subject: '',
+    body: '',
+    from: '',
+  });
+
+  const quotes = getFilteredQuotes();
+  const stats = getQuoteStats();
+
+  const handleImport = () => {
+    if (!importEmail.subject && !importEmail.body) return;
+
+    importFromEmail({
+      ...importEmail,
+      receivedAt: new Date().toISOString(),
+    });
+
+    setImportEmail({ subject: '', body: '', from: '' });
+    setShowImportModal(false);
+  };
+
+  const formatCurrency = (value: number | null, currency: string = 'USD') => {
+    if (value === null) return '—';
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+    }).format(value);
+  };
+
+  const formatDate = (timestamp: number | string) => {
+    const date = typeof timestamp === 'string' ? new Date(timestamp) : new Date(timestamp);
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex justify-between items-center">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Manufacturer Quotes</h1>
+          <p className="text-gray-500 mt-1">
+            {stats.total} total quotes • Parse and review bids from supplier emails
+          </p>
+        </div>
+        <button
+          onClick={() => setShowImportModal(true)}
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors flex items-center gap-2"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+          </svg>
+          Import Email
+        </button>
+      </div>
+
+      {/* Stats Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
+        {(Object.keys(BID_STATUS_LABELS) as BidStatus[]).map((status) => (
+          <button
+            key={status}
+            onClick={() => setFilterStatus(filterStatus === status ? 'all' : status)}
+            className={`p-4 rounded-lg border-2 transition-all ${
+              filterStatus === status
+                ? 'border-blue-500 bg-blue-50'
+                : 'border-gray-200 hover:border-gray-300'
+            }`}
+          >
+            <div className="text-2xl font-bold text-gray-900">{stats.byStatus[status]}</div>
+            <div className={`text-sm font-medium ${BID_STATUS_COLORS[status].replace('bg-', 'text-').replace('100', '700')}`}>
+              {BID_STATUS_LABELS[status]}
+            </div>
+          </button>
+        ))}
+      </div>
+
+      {/* Search and Filter */}
+      <div className="flex gap-4">
+        <div className="flex-1">
+          <input
+            type="text"
+            placeholder="Search by supplier, product, or email..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+        </div>
+        {filterStatus !== 'all' && (
+          <button
+            onClick={() => setFilterStatus('all')}
+            className="px-4 py-2 text-gray-600 hover:text-gray-800"
+          >
+            Clear Filter
+          </button>
+        )}
+      </div>
+
+      {/* Quotes Table */}
+      <div className="bg-white rounded-lg shadow overflow-hidden">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Supplier
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Product
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Unit Cost
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                MOQ
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Lead Time
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Confidence
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Status
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Received
+              </th>
+              <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {quotes.map((quote) => (
+              <tr
+                key={quote.id}
+                className="hover:bg-gray-50 cursor-pointer"
+                onClick={() => navigate(`/bids/${quote.id}`)}
+              >
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <div className="text-sm font-medium text-gray-900">{quote.supplierName}</div>
+                  <div className="text-sm text-gray-500">{quote.supplierEmail}</div>
+                </td>
+                <td className="px-6 py-4">
+                  <div className="text-sm text-gray-900 max-w-xs truncate">
+                    {quote.productDescription}
+                  </div>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <div className={`text-sm font-medium ${CONFIDENCE_COLORS[quote.unitCost.confidence]}`}>
+                    {formatCurrency(quote.unitCost.value, quote.currency)}
+                  </div>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <div className={`text-sm ${CONFIDENCE_COLORS[quote.moq.confidence]}`}>
+                    {quote.moq.value?.toLocaleString() ?? '—'}
+                  </div>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <div className={`text-sm ${CONFIDENCE_COLORS[quote.leadTimeDays.confidence]}`}>
+                    {quote.leadTimeDays.value ? `${quote.leadTimeDays.value} days` : '—'}
+                  </div>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <span className={`text-sm font-medium ${CONFIDENCE_COLORS[quote.overallConfidence]}`}>
+                    {CONFIDENCE_LABELS[quote.overallConfidence]}
+                  </span>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${BID_STATUS_COLORS[quote.status]}`}>
+                    {BID_STATUS_LABELS[quote.status]}
+                  </span>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  {formatDate(quote.emailReceivedAt)}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (window.confirm('Delete this quote?')) {
+                        deleteQuote(quote.id);
+                      }
+                    }}
+                    className="text-red-600 hover:text-red-900"
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {quotes.length === 0 && (
+              <tr>
+                <td colSpan={9} className="px-6 py-12 text-center text-gray-500">
+                  No quotes found. Import an email to get started.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Import Modal */}
+      {showImportModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl mx-4">
+            <div className="flex justify-between items-center px-6 py-4 border-b">
+              <h2 className="text-xl font-semibold text-gray-900">Import Quote Email</h2>
+              <button
+                onClick={() => setShowImportModal(false)}
+                className="text-gray-400 hover:text-gray-600"
+              >
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <div className="px-6 py-4 space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  From (Sender Email)
+                </label>
+                <input
+                  type="text"
+                  value={importEmail.from}
+                  onChange={(e) => setImportEmail({ ...importEmail, from: e.target.value })}
+                  placeholder="supplier@example.com or Name <email@example.com>"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Subject
+                </label>
+                <input
+                  type="text"
+                  value={importEmail.subject}
+                  onChange={(e) => setImportEmail({ ...importEmail, subject: e.target.value })}
+                  placeholder="RE: Quote Request - Product Name"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Email Body
+                </label>
+                <textarea
+                  value={importEmail.body}
+                  onChange={(e) => setImportEmail({ ...importEmail, body: e.target.value })}
+                  placeholder="Paste the full email content here..."
+                  rows={12}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono text-sm"
+                />
+              </div>
+              <p className="text-sm text-gray-500">
+                The parser will automatically extract unit cost, MOQ, lead time, tooling costs, and payment terms from the email.
+              </p>
+            </div>
+            <div className="flex justify-end gap-3 px-6 py-4 border-t bg-gray-50">
+              <button
+                onClick={() => setShowImportModal(false)}
+                className="px-4 py-2 text-gray-700 hover:text-gray-900"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleImport}
+                disabled={!importEmail.body}
+                className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Parse & Import
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/bids/README.md
+++ b/src/bids/README.md
@@ -1,0 +1,99 @@
+# Bids Module
+
+Email ingestion and parsing for manufacturer quotes.
+
+## Purpose
+
+This module allows users to:
+1. Import quote emails from manufacturers
+2. Automatically parse key data (unit cost, MOQ, lead time, tooling, payment terms)
+3. Review and correct parsed data with confidence indicators
+4. Track quote status through the procurement workflow
+
+## Related PRD/Issues
+
+- Issue #26: Email ingestion for manufacturer quotes
+
+## Components
+
+### BidList (`BidList.tsx`)
+Main list view showing all imported quotes with:
+- Status filtering (draft, parsed, reviewed, accepted, rejected, expired)
+- Search by supplier/product/email
+- Statistics dashboard
+- Email import modal
+
+### BidDetail (`BidDetail.tsx`)
+Detail/edit view with:
+- Editable parsed fields with confidence indicators
+- Original email display for reference
+- Status management (review, accept, reject)
+- Notes and metadata
+
+## Email Parser (`emailParser.ts`)
+
+Regex-based parser that extracts:
+- **Unit Cost**: "$1.50", "USD 1.50", "1.50 USD", "unit price: $1.50"
+- **MOQ**: "MOQ: 1000", "minimum order: 1,000 units", "min qty 1000"
+- **Lead Time**: "lead time: 30 days", "4-6 weeks", "30 day turnaround"
+- **Tooling Costs**: "tooling: $5,000", "mold cost: $5000"
+- **Payment Terms**: "Net 30", "50% deposit", "T/T 30 days"
+
+Each field includes a confidence score (high/medium/low) based on pattern match quality.
+
+## Store (`store.ts`)
+
+Zustand store managing:
+- Quote CRUD operations
+- Email import/parsing
+- Field-level updates with confidence tracking
+- Status transitions
+- Filtering and search
+
+## Usage
+
+```tsx
+import { BidList, BidDetail, useBidsStore, parseQuoteEmail } from './bids';
+
+// In router
+<Route path="/bids" element={<BidList />} />
+<Route path="/bids/:id" element={<BidDetail />} />
+
+// Programmatic import
+const { importFromEmail } = useBidsStore();
+const quote = importFromEmail({
+  subject: 'RE: Quote Request',
+  body: 'Unit price: $4.50, MOQ: 5000 units...',
+  from: 'supplier@example.com',
+  receivedAt: new Date().toISOString(),
+});
+
+// Direct parsing
+const result = parseQuoteEmail(emailData);
+console.log(result.quote.unitCost.value); // 4.50
+console.log(result.quote.unitCost.confidence); // 'high'
+```
+
+## Workflow
+
+1. **Import**: User pastes email into import modal
+2. **Parse**: System extracts data with confidence scores
+3. **Review**: User corrects any low-confidence or incorrect fields
+4. **Accept/Reject**: User makes final decision on quote
+
+## Integration Points
+
+- **Supply Chain Module**: Accepted quotes can be converted to Purchase Orders
+- **Supplier Module**: Quotes linked to existing suppliers via `supplierId`
+- **Production Module**: Quote data feeds into BOM cost calculations
+
+## Dependencies
+
+- `zustand` - State management
+- `react-router-dom` - Routing
+
+## Testing
+
+```bash
+npm run test -- src/bids
+```

--- a/src/bids/__tests__/emailParser.test.ts
+++ b/src/bids/__tests__/emailParser.test.ts
@@ -1,0 +1,300 @@
+/**
+ * @file emailParser.test.ts
+ * @description Unit tests for email quote parser
+ * @related-prd Issue #26 - Email ingestion for manufacturer quotes
+ * @author Ralph (AI Agent)
+ * @created 2026-01-23
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseQuoteEmail, extractPricingTiers } from '../emailParser';
+
+describe('parseQuoteEmail', () => {
+  describe('unit cost extraction', () => {
+    it('extracts unit price with dollar sign and per unit', () => {
+      const result = parseQuoteEmail({
+        subject: 'Quote',
+        body: 'Unit price: $4.75 per unit',
+        from: 'test@example.com',
+        receivedAt: '2026-01-23T00:00:00Z',
+      });
+      expect(result.quote.unitCost?.value).toBe(4.75);
+      expect(result.quote.unitCost?.confidence).toBe('high');
+    });
+
+    it('extracts unit cost with USD notation', () => {
+      const result = parseQuoteEmail({
+        subject: 'Quote',
+        body: 'Price is USD 3.50/pc',
+        from: 'test@example.com',
+        receivedAt: '2026-01-23T00:00:00Z',
+      });
+      expect(result.quote.unitCost?.value).toBe(3.5);
+    });
+
+    it('extracts price with comma formatting', () => {
+      const result = parseQuoteEmail({
+        subject: 'Quote',
+        body: 'Unit cost: $1,250.00 per piece',
+        from: 'test@example.com',
+        receivedAt: '2026-01-23T00:00:00Z',
+      });
+      expect(result.quote.unitCost?.value).toBe(1250);
+    });
+  });
+
+  describe('MOQ extraction', () => {
+    it('extracts MOQ with standard format', () => {
+      const result = parseQuoteEmail({
+        subject: 'Quote',
+        body: 'MOQ: 5,000 units',
+        from: 'test@example.com',
+        receivedAt: '2026-01-23T00:00:00Z',
+      });
+      expect(result.quote.moq?.value).toBe(5000);
+      expect(result.quote.moq?.confidence).toBe('high');
+    });
+
+    it('extracts minimum order quantity', () => {
+      const result = parseQuoteEmail({
+        subject: 'Quote',
+        body: 'Minimum order quantity is 3000 pcs',
+        from: 'test@example.com',
+        receivedAt: '2026-01-23T00:00:00Z',
+      });
+      expect(result.quote.moq?.value).toBe(3000);
+    });
+
+    it('extracts min qty shorthand', () => {
+      const result = parseQuoteEmail({
+        subject: 'Quote',
+        body: 'Min qty 1000',
+        from: 'test@example.com',
+        receivedAt: '2026-01-23T00:00:00Z',
+      });
+      expect(result.quote.moq?.value).toBe(1000);
+    });
+  });
+
+  describe('lead time extraction', () => {
+    it('extracts lead time in days', () => {
+      const result = parseQuoteEmail({
+        subject: 'Quote',
+        body: 'Lead time: 30 days',
+        from: 'test@example.com',
+        receivedAt: '2026-01-23T00:00:00Z',
+      });
+      expect(result.quote.leadTimeDays?.value).toBe(30);
+    });
+
+    it('converts weeks to days', () => {
+      const result = parseQuoteEmail({
+        subject: 'Quote',
+        body: 'Lead time: 6 weeks',
+        from: 'test@example.com',
+        receivedAt: '2026-01-23T00:00:00Z',
+      });
+      expect(result.quote.leadTimeDays?.value).toBe(42);
+    });
+
+    it('extracts delivery time variant', () => {
+      const result = parseQuoteEmail({
+        subject: 'Quote',
+        body: 'Delivery time: 45 days after deposit',
+        from: 'test@example.com',
+        receivedAt: '2026-01-23T00:00:00Z',
+      });
+      expect(result.quote.leadTimeDays?.value).toBe(45);
+    });
+  });
+
+  describe('tooling cost extraction', () => {
+    it('extracts mold cost', () => {
+      const result = parseQuoteEmail({
+        subject: 'Quote',
+        body: 'Mold cost: $3,500',
+        from: 'test@example.com',
+        receivedAt: '2026-01-23T00:00:00Z',
+      });
+      expect(result.quote.toolingCosts?.value?.moldCost).toBe(3500);
+      expect(result.quote.toolingCosts?.value?.total).toBe(3500);
+    });
+
+    it('extracts tooling fee', () => {
+      const result = parseQuoteEmail({
+        subject: 'Quote',
+        body: 'Tooling: $5000',
+        from: 'test@example.com',
+        receivedAt: '2026-01-23T00:00:00Z',
+      });
+      expect(result.quote.toolingCosts?.value?.total).toBe(5000);
+    });
+
+    it('extracts setup cost separately', () => {
+      const result = parseQuoteEmail({
+        subject: 'Quote',
+        body: 'Mold: $3,000\nSetup cost: $500',
+        from: 'test@example.com',
+        receivedAt: '2026-01-23T00:00:00Z',
+      });
+      expect(result.quote.toolingCosts?.value?.moldCost).toBe(3000);
+      expect(result.quote.toolingCosts?.value?.setupCost).toBe(500);
+      expect(result.quote.toolingCosts?.value?.total).toBe(3500);
+    });
+  });
+
+  describe('payment terms extraction', () => {
+    it('extracts Net 30 terms', () => {
+      const result = parseQuoteEmail({
+        subject: 'Quote',
+        body: 'Payment terms: Net 30',
+        from: 'test@example.com',
+        receivedAt: '2026-01-23T00:00:00Z',
+      });
+      expect(result.quote.paymentTerms?.value?.type).toContain('30');
+      expect(result.quote.paymentTerms?.value?.netDays).toBe(30);
+    });
+
+    it('extracts deposit terms', () => {
+      const result = parseQuoteEmail({
+        subject: 'Quote',
+        body: 'Terms: 50% deposit, 50% on shipment',
+        from: 'test@example.com',
+        receivedAt: '2026-01-23T00:00:00Z',
+      });
+      expect(result.quote.paymentTerms?.value?.depositPercent).toBe(50);
+    });
+  });
+
+  describe('currency detection', () => {
+    it('detects USD from dollar sign', () => {
+      const result = parseQuoteEmail({
+        subject: 'Quote',
+        body: 'Price: $5.00',
+        from: 'test@example.com',
+        receivedAt: '2026-01-23T00:00:00Z',
+      });
+      expect(result.quote.currency).toBe('USD');
+    });
+
+    it('detects EUR from symbol', () => {
+      const result = parseQuoteEmail({
+        subject: 'Quote',
+        body: 'Price: €5.00',
+        from: 'test@example.com',
+        receivedAt: '2026-01-23T00:00:00Z',
+      });
+      expect(result.quote.currency).toBe('EUR');
+    });
+
+    it('detects currency code in text', () => {
+      const result = parseQuoteEmail({
+        subject: 'Quote',
+        body: 'Price: 5.00 GBP per unit',
+        from: 'test@example.com',
+        receivedAt: '2026-01-23T00:00:00Z',
+      });
+      expect(result.quote.currency).toBe('GBP');
+    });
+  });
+
+  describe('supplier extraction', () => {
+    it('extracts supplier name from email domain', () => {
+      const result = parseQuoteEmail({
+        subject: 'Quote',
+        body: 'Hello',
+        from: 'sales@shenzhen-sports.cn',
+        receivedAt: '2026-01-23T00:00:00Z',
+      });
+      expect(result.quote.supplierName).toBe('Shenzhen-sports');
+    });
+
+    it('extracts supplier email from angle brackets', () => {
+      const result = parseQuoteEmail({
+        subject: 'Quote',
+        body: 'Hello',
+        from: 'John Doe <john@factory.com>',
+        receivedAt: '2026-01-23T00:00:00Z',
+      });
+      expect(result.quote.supplierEmail).toBe('john@factory.com');
+    });
+  });
+
+  describe('full email parsing', () => {
+    it('parses a complete manufacturer quote email', () => {
+      const email = {
+        subject: 'RE: Quote Request - Lacrosse Head',
+        body: `Dear Customer,
+
+Thank you for your inquiry. Please find our quotation below:
+
+Product: Premium Lacrosse Head
+Unit price: $4.50 USD per piece (FOB)
+MOQ: 5,000 units
+Lead time: 45 days after deposit
+Mold cost: $3,500 (one-time)
+Setup fee: $500
+
+Payment terms: 30% deposit, 70% before shipment
+
+Best regards,
+Sales Team`,
+        from: 'Wang Wei <sales@manufacturer.cn>',
+        receivedAt: '2026-01-23T10:00:00Z',
+      };
+
+      const result = parseQuoteEmail(email);
+
+      expect(result.success).toBe(true);
+      expect(result.quote.unitCost?.value).toBe(4.5);
+      expect(result.quote.moq?.value).toBe(5000);
+      expect(result.quote.leadTimeDays?.value).toBe(45);
+      expect(result.quote.toolingCosts?.value?.moldCost).toBe(3500);
+      expect(result.quote.toolingCosts?.value?.setupCost).toBe(500);
+      expect(result.quote.paymentTerms?.value?.depositPercent).toBe(30);
+      expect(result.quote.currency).toBe('USD');
+      expect(result.quote.supplierEmail).toBe('sales@manufacturer.cn');
+    });
+
+    it('handles emails with missing data gracefully', () => {
+      const result = parseQuoteEmail({
+        subject: 'Quote',
+        body: 'We can make your product. Contact us for pricing.',
+        from: 'info@company.com',
+        receivedAt: '2026-01-23T00:00:00Z',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.warnings.length).toBeGreaterThan(0);
+      expect(result.quote.unitCost?.value).toBeNull();
+      expect(result.quote.unitCost?.confidence).toBe('low');
+    });
+  });
+});
+
+describe('extractPricingTiers', () => {
+  it('extracts range-based pricing tiers', () => {
+    const text = '1000-4999: $2.50\n5000-9999: $2.00';
+    const tiers = extractPricingTiers(text);
+    
+    expect(tiers).toHaveLength(2);
+    expect(tiers[0]).toEqual({ minQuantity: 1000, maxQuantity: 4999, unitPrice: 2.5 });
+    expect(tiers[1]).toEqual({ minQuantity: 5000, maxQuantity: 9999, unitPrice: 2.0 });
+  });
+
+  it('extracts open-ended tiers', () => {
+    const text = '10000+ units: $1.75';
+    const tiers = extractPricingTiers(text);
+    
+    expect(tiers).toHaveLength(1);
+    expect(tiers[0]).toEqual({ minQuantity: 10000, unitPrice: 1.75 });
+  });
+
+  it('sorts tiers by quantity', () => {
+    const text = '5000+: $1.50\n1000-4999: $2.00';
+    const tiers = extractPricingTiers(text);
+    
+    expect(tiers[0].minQuantity).toBe(1000);
+    expect(tiers[1].minQuantity).toBe(5000);
+  });
+});

--- a/src/bids/emailParser.ts
+++ b/src/bids/emailParser.ts
@@ -1,0 +1,434 @@
+/**
+ * @file emailParser.ts
+ * @description Email parsing service for extracting manufacturer quote data
+ * @related-prd Issue #26 - Email ingestion for manufacturer quotes
+ * @author Ralph (AI Agent)
+ * @created 2026-01-23
+ */
+
+import type {
+  EmailInput,
+  ParseResult,
+  ManufacturerQuote,
+  ParsedField,
+  ParseConfidence,
+  ToolingCost,
+  PaymentTerms,
+  PricingTier,
+} from './types';
+
+// Re-export EmailInput for convenience
+export type { EmailInput };
+
+/**
+ * Regex patterns for extracting quote data from emails
+ */
+const PATTERNS = {
+  // Unit cost patterns: "$1.50", "USD 1.50", "1.50 USD", "$1.50/unit", "unit price: $1.50"
+  unitCost: [
+    /(?:unit\s*(?:price|cost)|price\s*per\s*unit|cost\s*per\s*unit|ppu)\s*[:=]?\s*\$?\s*([\d,]+\.?\d*)\s*(?:USD|usd)?/i,
+    /\$\s*([\d,]+\.?\d*)\s*(?:\/?\s*(?:unit|pc|pcs|piece|ea|each))/i,
+    /(?:USD|usd)\s*([\d,]+\.?\d*)\s*(?:\/?\s*(?:unit|pc|pcs|piece|ea|each))/i,
+    /([\d,]+\.?\d*)\s*(?:USD|usd)\s*(?:\/?\s*(?:unit|pc|pcs|piece|ea|each))/i,
+  ],
+
+  // MOQ patterns: "MOQ: 1000", "minimum order: 1,000 units", "min qty 1000"
+  moq: [
+    /(?:moq|minimum\s*order\s*(?:quantity|qty)?|min\.?\s*(?:order|qty|quantity))\s*[:=]?\s*(?:is\s*)?([\d,]+)\s*(?:units?|pcs?|pieces?)?/i,
+    /(?:minimum|min\.?)\s*[:=]?\s*(?:is\s*)?([\d,]+)\s*(?:units?|pcs?|pieces?)/i,
+    /([\d,]+)\s*(?:units?|pcs?|pieces?)\s*(?:minimum|min\.?)/i,
+  ],
+
+  // Lead time patterns: "lead time: 30 days", "delivery: 4-6 weeks", "30 day lead time"
+  leadTime: [
+    /(?:lead\s*time|delivery\s*time|production\s*time|turnaround)\s*[:=]?\s*(\d+)(?:\s*-\s*\d+)?\s*(?:days?|d)/i,
+    /(?:lead\s*time|delivery\s*time|production\s*time|turnaround)\s*[:=]?\s*(\d+)(?:\s*-\s*\d+)?\s*(?:weeks?|wks?)/i,
+    /(\d+)(?:\s*-\s*\d+)?\s*(?:days?|d)\s*(?:lead\s*time|delivery|turnaround)/i,
+    /(\d+)(?:\s*-\s*\d+)?\s*(?:weeks?|wks?)\s*(?:lead\s*time|delivery|turnaround)/i,
+  ],
+
+  // Tooling/mold costs: "tooling: $5,000", "mold cost: $5000", "tooling fee: $5,000"
+  tooling: [
+    /(?:tooling|mold|mould|die)\s*(?:cost|fee|charge|price)?\s*[:=]?\s*\$?\s*([\d,]+\.?\d*)/i,
+    /\$\s*([\d,]+\.?\d*)\s*(?:tooling|mold|mould|die)/i,
+    /(?:setup|set-up)\s*(?:cost|fee|charge)?\s*[:=]?\s*\$?\s*([\d,]+\.?\d*)/i,
+  ],
+
+  // Payment terms: "Net 30", "50% deposit", "T/T 30 days"
+  paymentTerms: [
+    /(?:payment\s*terms?|terms?)\s*[:=]?\s*((?:net|n)\s*\d+)/i,
+    /(\d+%?\s*(?:deposit|down|upfront)(?:\s*,?\s*\d+%?\s*(?:on|upon|at)\s*(?:shipment|delivery|completion))?)/i,
+    /(T\/T\s*\d+\s*days?)/i,
+    /(?:payment\s*terms?|terms?)\s*[:=]?\s*([^.\n]{5,50})/i,
+  ],
+
+  // Currency detection
+  currency: [
+    /\b(USD|EUR|GBP|CNY|RMB|JPY)\b/i,
+    /(\$|€|£|¥|￥)/,
+  ],
+
+  // Pricing tiers: "1000-4999: $1.50, 5000+: $1.25"
+  pricingTiers: [
+    /(\d[\d,]*)\s*(?:-|to)\s*(\d[\d,]*)\s*(?:units?|pcs?)?\s*[:=@]?\s*\$?\s*([\d.]+)/gi,
+    /(\d[\d,]*)\s*\+\s*(?:units?|pcs?)?\s*[:=@]?\s*\$?\s*([\d.]+)/gi,
+  ],
+
+  // Email sender extraction
+  emailFrom: [
+    /<([^>]+@[^>]+)>/,
+    /([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/,
+  ],
+};
+
+/**
+ * Parse a number from string, handling commas
+ */
+function parseNumber(str: string): number | null {
+  if (!str) return null;
+  const cleaned = str.replace(/,/g, '').trim();
+  const num = parseFloat(cleaned);
+  return isNaN(num) ? null : num;
+}
+
+/**
+ * Determine confidence based on pattern match quality
+ */
+function determineConfidence(
+  value: unknown,
+  matchedPattern: RegExp | null,
+  originalText: string
+): ParseConfidence {
+  if (value === null || value === undefined) return 'low';
+  if (!matchedPattern) return 'low';
+  
+  // Check if the original text looks clean/unambiguous
+  const textLength = originalText.trim().length;
+  if (textLength < 5) return 'low';
+  if (textLength > 100) return 'medium'; // Long text = more context = might be ambiguous
+  
+  // First pattern in each array is usually most specific
+  return 'high';
+}
+
+/**
+ * Extract unit cost from email body
+ */
+function extractUnitCost(text: string): ParsedField<number> {
+  for (const pattern of PATTERNS.unitCost) {
+    const match = text.match(pattern);
+    if (match) {
+      const value = parseNumber(match[1]);
+      if (value !== null && value > 0 && value < 10000) { // Sanity check
+        return {
+          value,
+          confidence: determineConfidence(value, pattern, match[0]),
+          originalText: match[0],
+          manuallyEdited: false,
+        };
+      }
+    }
+  }
+  return { value: null, confidence: 'low', originalText: '', manuallyEdited: false };
+}
+
+/**
+ * Extract MOQ from email body
+ */
+function extractMOQ(text: string): ParsedField<number> {
+  for (const pattern of PATTERNS.moq) {
+    const match = text.match(pattern);
+    if (match) {
+      const value = parseNumber(match[1]);
+      if (value !== null && value > 0 && value < 10000000) { // Sanity check
+        return {
+          value,
+          confidence: determineConfidence(value, pattern, match[0]),
+          originalText: match[0],
+          manuallyEdited: false,
+        };
+      }
+    }
+  }
+  return { value: null, confidence: 'low', originalText: '', manuallyEdited: false };
+}
+
+/**
+ * Extract lead time in days from email body
+ */
+function extractLeadTime(text: string): ParsedField<number> {
+  for (let i = 0; i < PATTERNS.leadTime.length; i++) {
+    const pattern = PATTERNS.leadTime[i];
+    const match = text.match(pattern);
+    if (match) {
+      let value = parseNumber(match[1]);
+      if (value !== null) {
+        // Convert weeks to days for patterns 1 and 3 (week patterns)
+        if (i === 1 || i === 3) {
+          value = value * 7;
+        }
+        if (value > 0 && value < 365) { // Sanity check
+          return {
+            value,
+            confidence: determineConfidence(value, pattern, match[0]),
+            originalText: match[0],
+            manuallyEdited: false,
+          };
+        }
+      }
+    }
+  }
+  return { value: null, confidence: 'low', originalText: '', manuallyEdited: false };
+}
+
+/**
+ * Extract tooling costs from email body
+ */
+function extractToolingCosts(text: string): ParsedField<ToolingCost> {
+  const costs: ToolingCost = {
+    moldCost: 0,
+    setupCost: 0,
+    otherCosts: 0,
+    total: 0,
+  };
+  
+  let foundAny = false;
+  let originalTexts: string[] = [];
+  
+  for (const pattern of PATTERNS.tooling) {
+    const matches = text.matchAll(new RegExp(pattern, 'gi'));
+    for (const match of matches) {
+      const value = parseNumber(match[1]);
+      if (value !== null && value > 0) {
+        foundAny = true;
+        originalTexts.push(match[0]);
+        
+        const lowerMatch = match[0].toLowerCase();
+        if (lowerMatch.includes('mold') || lowerMatch.includes('mould') || lowerMatch.includes('die')) {
+          costs.moldCost += value;
+        } else if (lowerMatch.includes('setup') || lowerMatch.includes('set-up')) {
+          costs.setupCost += value;
+        } else {
+          costs.otherCosts += value;
+        }
+      }
+    }
+  }
+  
+  costs.total = costs.moldCost + costs.setupCost + costs.otherCosts;
+  
+  if (!foundAny) {
+    return { value: null, confidence: 'low', originalText: '', manuallyEdited: false };
+  }
+  
+  return {
+    value: costs,
+    confidence: costs.total > 0 ? 'medium' : 'low',
+    originalText: originalTexts.join('; '),
+    manuallyEdited: false,
+  };
+}
+
+/**
+ * Extract payment terms from email body
+ */
+function extractPaymentTerms(text: string): ParsedField<PaymentTerms> {
+  for (const pattern of PATTERNS.paymentTerms) {
+    const match = text.match(pattern);
+    if (match && match[1]) {
+      const termsText = match[1].trim();
+      const terms: PaymentTerms = { type: termsText };
+      
+      // Try to extract specific values
+      const netMatch = termsText.match(/(?:net|n)\s*(\d+)/i);
+      if (netMatch) {
+        terms.netDays = parseInt(netMatch[1], 10);
+      }
+      
+      const depositMatch = termsText.match(/(\d+)%?\s*(?:deposit|down|upfront)/i);
+      if (depositMatch) {
+        terms.depositPercent = parseInt(depositMatch[1], 10);
+      }
+      
+      return {
+        value: terms,
+        confidence: terms.netDays || terms.depositPercent ? 'high' : 'medium',
+        originalText: match[0],
+        manuallyEdited: false,
+      };
+    }
+  }
+  return { value: null, confidence: 'low', originalText: '', manuallyEdited: false };
+}
+
+/**
+ * Extract currency from email body
+ */
+function extractCurrency(text: string): string {
+  for (const pattern of PATTERNS.currency) {
+    const match = text.match(pattern);
+    if (match) {
+      const curr = match[1] || match[0];
+      switch (curr) {
+        case '$': return 'USD';
+        case '€': return 'EUR';
+        case '£': return 'GBP';
+        case '¥':
+        case '￥':
+          return text.match(/CNY|RMB/i) ? 'CNY' : 'JPY';
+        default:
+          return curr.toUpperCase();
+      }
+    }
+  }
+  return 'USD'; // Default
+}
+
+/**
+ * Extract supplier name from email
+ */
+function extractSupplierName(email: EmailInput): string {
+  // Try to get company name from email domain
+  const emailMatch = email.from.match(/@([^.]+)\./);
+  if (emailMatch) {
+    // Capitalize first letter
+    return emailMatch[1].charAt(0).toUpperCase() + emailMatch[1].slice(1);
+  }
+  
+  // Try to extract from "From: Name <email>" format
+  const nameMatch = email.from.match(/^([^<]+)</);
+  if (nameMatch) {
+    return nameMatch[1].trim();
+  }
+  
+  return email.from;
+}
+
+/**
+ * Extract supplier email address
+ */
+function extractSupplierEmail(from: string): string {
+  for (const pattern of PATTERNS.emailFrom) {
+    const match = from.match(pattern);
+    if (match) {
+      return match[1];
+    }
+  }
+  return from;
+}
+
+/**
+ * Calculate overall confidence from individual field confidences
+ */
+function calculateOverallConfidence(quote: Partial<ManufacturerQuote>): ParseConfidence {
+  const fields = [
+    quote.unitCost?.confidence,
+    quote.moq?.confidence,
+    quote.leadTimeDays?.confidence,
+    quote.paymentTerms?.confidence,
+  ].filter(Boolean) as ParseConfidence[];
+  
+  if (fields.length === 0) return 'low';
+  
+  const scores = { high: 3, medium: 2, low: 1, manual: 3 };
+  const avgScore = fields.reduce((sum, c) => sum + scores[c], 0) / fields.length;
+  
+  if (avgScore >= 2.5) return 'high';
+  if (avgScore >= 1.5) return 'medium';
+  return 'low';
+}
+
+/**
+ * Extract pricing tiers from email body
+ */
+export function extractPricingTiers(text: string): PricingTier[] {
+  const tiers: PricingTier[] = [];
+  
+  // Match range patterns: "1000-4999: $1.50"
+  const rangePattern = /(\d[\d,]*)\s*(?:-|to)\s*(\d[\d,]*)\s*(?:units?|pcs?)?\s*[:=@]?\s*\$?\s*([\d.]+)/gi;
+  let match;
+  while ((match = rangePattern.exec(text)) !== null) {
+    const minQty = parseNumber(match[1]);
+    const maxQty = parseNumber(match[2]);
+    const price = parseNumber(match[3]);
+    if (minQty !== null && maxQty !== null && price !== null) {
+      tiers.push({ minQuantity: minQty, maxQuantity: maxQty, unitPrice: price });
+    }
+  }
+  
+  // Match open-ended patterns: "5000+: $1.25"
+  const openPattern = /(\d[\d,]*)\s*\+\s*(?:units?|pcs?)?\s*[:=@]?\s*\$?\s*([\d.]+)/gi;
+  while ((match = openPattern.exec(text)) !== null) {
+    const minQty = parseNumber(match[1]);
+    const price = parseNumber(match[2]);
+    if (minQty !== null && price !== null) {
+      tiers.push({ minQuantity: minQty, unitPrice: price });
+    }
+  }
+  
+  // Sort by minimum quantity
+  return tiers.sort((a, b) => a.minQuantity - b.minQuantity);
+}
+
+/**
+ * Main parsing function - extracts all quote data from an email
+ */
+export function parseQuoteEmail(email: EmailInput): ParseResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  
+  const combinedText = `${email.subject}\n\n${email.body}`;
+  
+  // Extract all fields
+  const unitCost = extractUnitCost(combinedText);
+  const moq = extractMOQ(combinedText);
+  const leadTimeDays = extractLeadTime(combinedText);
+  const toolingCosts = extractToolingCosts(combinedText);
+  const paymentTerms = extractPaymentTerms(combinedText);
+  const currency = extractCurrency(combinedText);
+  
+  // Validation warnings
+  if (!unitCost.value) {
+    warnings.push('Could not extract unit cost from email');
+  }
+  if (!moq.value) {
+    warnings.push('Could not extract MOQ from email');
+  }
+  if (!leadTimeDays.value) {
+    warnings.push('Could not extract lead time from email');
+  }
+  
+  const quote: Partial<ManufacturerQuote> = {
+    supplierName: extractSupplierName(email),
+    supplierEmail: extractSupplierEmail(email.from),
+    unitCost,
+    moq,
+    leadTimeDays,
+    toolingCosts,
+    paymentTerms,
+    currency,
+    productDescription: email.subject,
+    emailSubject: email.subject,
+    emailBody: email.body,
+    emailReceivedAt: email.receivedAt,
+    emailFrom: email.from,
+    status: 'parsed',
+    notes: '',
+  };
+  
+  quote.overallConfidence = calculateOverallConfidence(quote);
+  
+  return {
+    success: errors.length === 0,
+    quote,
+    errors,
+    warnings,
+  };
+}
+
+/**
+ * Parse multiple emails and return quotes
+ */
+export function parseMultipleEmails(emails: EmailInput[]): ParseResult[] {
+  return emails.map(parseQuoteEmail);
+}

--- a/src/bids/index.ts
+++ b/src/bids/index.ts
@@ -1,0 +1,41 @@
+/**
+ * @file index.ts
+ * @description Bids module exports - Email quote parsing for manufacturer bids
+ * @related-prd Issue #26 - Email ingestion for manufacturer quotes
+ * @author Ralph (AI Agent)
+ * @created 2026-01-23
+ */
+
+// Components
+export { BidList } from './BidList';
+export { BidDetail } from './BidDetail';
+
+// Store
+export { useBidsStore } from './store';
+
+// Parser
+export { parseQuoteEmail, parseMultipleEmails, extractPricingTiers } from './emailParser';
+
+// Types
+export type {
+  ManufacturerQuote,
+  ManufacturerQuoteWithTiers,
+  ParsedField,
+  ParseConfidence,
+  PaymentTerms,
+  ToolingCost,
+  PricingTier,
+  BidStatus,
+  EmailInput,
+  ParseResult,
+} from './types';
+
+export {
+  BID_STATUS_LABELS,
+  BID_STATUS_COLORS,
+  CONFIDENCE_COLORS,
+  CONFIDENCE_LABELS,
+  DEFAULT_PARSED_FIELD,
+  DEFAULT_TOOLING_COST,
+  DEFAULT_PAYMENT_TERMS,
+} from './types';

--- a/src/bids/mockData.ts
+++ b/src/bids/mockData.ts
@@ -1,0 +1,344 @@
+/**
+ * @file mockData.ts
+ * @description Mock data for Bids module development and testing
+ * @related-prd Issue #26 - Email ingestion for manufacturer quotes
+ * @author Ralph (AI Agent)
+ * @created 2026-01-23
+ */
+
+import type { ManufacturerQuote } from './types';
+
+export const mockQuotes: ManufacturerQuote[] = [
+  {
+    id: 'bid-001',
+    supplierId: 'sup-001',
+    supplierName: 'Shenzhen Sports Manufacturing Co.',
+    supplierEmail: 'quotes@shenzhen-sports.cn',
+    unitCost: {
+      value: 4.75,
+      confidence: 'high',
+      originalText: 'Unit price: $4.75 USD per piece',
+      manuallyEdited: false,
+    },
+    moq: {
+      value: 5000,
+      confidence: 'high',
+      originalText: 'MOQ: 5,000 units',
+      manuallyEdited: false,
+    },
+    leadTimeDays: {
+      value: 45,
+      confidence: 'high',
+      originalText: 'Lead time: 45 days after deposit',
+      manuallyEdited: false,
+    },
+    toolingCosts: {
+      value: {
+        moldCost: 3500,
+        setupCost: 500,
+        otherCosts: 0,
+        total: 4000,
+      },
+      confidence: 'high',
+      originalText: 'Mold cost: $3,500; Setup fee: $500',
+      manuallyEdited: false,
+    },
+    paymentTerms: {
+      value: {
+        type: '30% deposit, 70% before shipment',
+        depositPercent: 30,
+      },
+      confidence: 'high',
+      originalText: 'Payment terms: 30% deposit, 70% before shipment',
+      manuallyEdited: false,
+    },
+    currency: 'USD',
+    productDescription: 'Premium Lacrosse Head - Model LH-2024',
+    validUntil: '2026-02-28',
+    emailSubject: 'RE: Quote Request - Lacrosse Head Manufacturing',
+    emailBody: `Dear Purchasing Team,
+
+Thank you for your inquiry regarding lacrosse head manufacturing. We are pleased to provide the following quotation:
+
+Product: Premium Lacrosse Head - Model LH-2024
+Material: Nylon 66 with 30% glass fiber reinforcement
+
+PRICING:
+Unit price: $4.75 USD per piece (FOB Shenzhen)
+
+MOQ: 5,000 units
+
+TOOLING:
+Mold cost: $3,500 (one-time, reusable for future orders)
+Setup fee: $500
+
+LEAD TIME:
+Lead time: 45 days after deposit and artwork approval
+
+PAYMENT TERMS:
+Payment terms: 30% deposit, 70% before shipment via T/T
+
+This quotation is valid until February 28, 2026.
+
+Best regards,
+Wang Wei
+Sales Manager
+Shenzhen Sports Manufacturing Co.`,
+    emailReceivedAt: '2026-01-20T09:30:00Z',
+    emailFrom: 'Wang Wei <quotes@shenzhen-sports.cn>',
+    status: 'parsed',
+    overallConfidence: 'high',
+    notes: '',
+    createdAt: Date.now() - 3 * 24 * 60 * 60 * 1000,
+    updatedAt: Date.now() - 3 * 24 * 60 * 60 * 1000,
+  },
+  {
+    id: 'bid-002',
+    supplierId: undefined,
+    supplierName: 'Taiwan Precision Plastics',
+    supplierEmail: 'sales@twprecision.com.tw',
+    unitCost: {
+      value: 5.25,
+      confidence: 'medium',
+      originalText: '$5.25/unit for standard spec',
+      manuallyEdited: false,
+    },
+    moq: {
+      value: 3000,
+      confidence: 'high',
+      originalText: 'Minimum order quantity is 3000 pcs',
+      manuallyEdited: false,
+    },
+    leadTimeDays: {
+      value: 35,
+      confidence: 'medium',
+      originalText: '5 weeks production time',
+      manuallyEdited: false,
+    },
+    toolingCosts: {
+      value: {
+        moldCost: 5000,
+        setupCost: 0,
+        otherCosts: 0,
+        total: 5000,
+      },
+      confidence: 'medium',
+      originalText: 'Tooling investment: USD 5,000',
+      manuallyEdited: false,
+    },
+    paymentTerms: {
+      value: {
+        type: 'Net 30',
+        netDays: 30,
+      },
+      confidence: 'high',
+      originalText: 'Terms: Net 30',
+      manuallyEdited: false,
+    },
+    currency: 'USD',
+    productDescription: 'Lacrosse Head - Standard Model',
+    validUntil: '2026-03-15',
+    emailSubject: 'Quote: Lacrosse Equipment Parts',
+    emailBody: `Hello,
+
+Following up on your RFQ for lacrosse equipment.
+
+Lacrosse Head - Standard Model
+$5.25/unit for standard spec
+
+Minimum order quantity is 3000 pcs
+5 weeks production time
+
+Tooling investment: USD 5,000 (amortized over first order)
+
+Terms: Net 30 for established customers
+
+Let me know if you need samples.
+
+Thanks,
+Jason Chen
+Taiwan Precision Plastics`,
+    emailReceivedAt: '2026-01-21T14:15:00Z',
+    emailFrom: 'Jason Chen <sales@twprecision.com.tw>',
+    status: 'reviewed',
+    overallConfidence: 'medium',
+    notes: 'Good quality reputation. Sample requested.',
+    createdAt: Date.now() - 2 * 24 * 60 * 60 * 1000,
+    updatedAt: Date.now() - 1 * 24 * 60 * 60 * 1000,
+    reviewedBy: 'Mike Johnson',
+    reviewedAt: Date.now() - 1 * 24 * 60 * 60 * 1000,
+  },
+  {
+    id: 'bid-003',
+    supplierId: undefined,
+    supplierName: 'Vietnam Manufacturing Partners',
+    supplierEmail: 'export@vnmfg.vn',
+    unitCost: {
+      value: 3.80,
+      confidence: 'low',
+      originalText: 'Around $3.80 depending on quantity',
+      manuallyEdited: false,
+    },
+    moq: {
+      value: 10000,
+      confidence: 'high',
+      originalText: 'MOQ 10,000 pieces',
+      manuallyEdited: false,
+    },
+    leadTimeDays: {
+      value: null,
+      confidence: 'low',
+      originalText: '',
+      manuallyEdited: false,
+    },
+    toolingCosts: {
+      value: {
+        moldCost: 2800,
+        setupCost: 0,
+        otherCosts: 0,
+        total: 2800,
+      },
+      confidence: 'medium',
+      originalText: 'Mold: $2,800',
+      manuallyEdited: false,
+    },
+    paymentTerms: {
+      value: null,
+      confidence: 'low',
+      originalText: '',
+      manuallyEdited: false,
+    },
+    currency: 'USD',
+    productDescription: 'Budget Lacrosse Head',
+    emailSubject: 'Fwd: RE: Lacrosse manufacturing inquiry',
+    emailBody: `Hi,
+
+We can make the lacrosse heads for you.
+
+Around $3.80 depending on quantity
+MOQ 10,000 pieces
+
+Mold: $2,800
+
+Quality same as competitors. We work with many US brands.
+
+Contact me for more details.
+
+Nguyen Thi
+Vietnam Manufacturing Partners`,
+    emailReceivedAt: '2026-01-22T08:45:00Z',
+    emailFrom: 'Nguyen Thi <export@vnmfg.vn>',
+    status: 'parsed',
+    overallConfidence: 'low',
+    notes: 'Parsing warnings:\nCould not extract lead time from email\nCould not extract payment terms from email',
+    createdAt: Date.now() - 1 * 24 * 60 * 60 * 1000,
+    updatedAt: Date.now() - 1 * 24 * 60 * 60 * 1000,
+  },
+  {
+    id: 'bid-004',
+    supplierId: 'sup-002',
+    supplierName: 'US Composites Inc.',
+    supplierEmail: 'sales@uscomposites.com',
+    unitCost: {
+      value: 12.50,
+      confidence: 'high',
+      originalText: 'Unit Cost: $12.50',
+      manuallyEdited: true,
+    },
+    moq: {
+      value: 500,
+      confidence: 'high',
+      originalText: 'MOQ: 500 units',
+      manuallyEdited: false,
+    },
+    leadTimeDays: {
+      value: 21,
+      confidence: 'high',
+      originalText: 'Lead Time: 21 days',
+      manuallyEdited: false,
+    },
+    toolingCosts: {
+      value: null,
+      confidence: 'manual',
+      originalText: '',
+      manuallyEdited: true,
+    },
+    paymentTerms: {
+      value: {
+        type: 'Net 45',
+        netDays: 45,
+      },
+      confidence: 'high',
+      originalText: 'Payment Terms: Net 45',
+      manuallyEdited: false,
+    },
+    currency: 'USD',
+    productDescription: 'Premium Carbon Fiber Lacrosse Head',
+    validUntil: '2026-04-01',
+    emailSubject: 'Quote #2024-1234 - Premium CF Lacrosse Head',
+    emailBody: `Quote #2024-1234
+
+Product: Premium Carbon Fiber Lacrosse Head
+Material: T700 Carbon Fiber, Clear Coat Finish
+
+Unit Cost: $12.50
+MOQ: 500 units
+Lead Time: 21 days from PO
+Payment Terms: Net 45
+
+Made in USA. All materials domestically sourced.
+
+This quote valid for 90 days.
+
+Best,
+Sarah Williams
+US Composites Inc.`,
+    emailReceivedAt: '2026-01-19T16:00:00Z',
+    emailFrom: 'Sarah Williams <sales@uscomposites.com>',
+    status: 'accepted',
+    overallConfidence: 'high',
+    notes: 'Premium domestic option. Higher cost but lower MOQ and faster turnaround.',
+    createdAt: Date.now() - 4 * 24 * 60 * 60 * 1000,
+    updatedAt: Date.now() - 2 * 24 * 60 * 60 * 1000,
+    reviewedBy: 'Mike Johnson',
+    reviewedAt: Date.now() - 3 * 24 * 60 * 60 * 1000,
+  },
+];
+
+// Sample emails for testing the parser
+export const sampleEmails = [
+  {
+    subject: 'RE: Quote Request - Sports Equipment Parts',
+    body: `Dear Sir/Madam,
+
+Thank you for your inquiry. Please find our quotation below:
+
+Product: Lacrosse Head - Custom Design
+Unit price: $6.50 USD/pc
+MOQ: 2000 units
+Lead time: 30-35 days
+Tooling cost: $4,500 (one-time)
+Payment terms: 50% deposit, 50% before shipping
+
+Best regards,
+Sales Team`,
+    from: 'sales@example-mfg.com',
+    receivedAt: new Date().toISOString(),
+  },
+  {
+    subject: 'Quotation for lacrosse equipment',
+    body: `Hi,
+
+Here's our quote:
+
+$3.25 per unit
+Minimum 8,000 pcs
+6 weeks delivery
+Mold fee $3,000
+Terms: Net 30
+
+Thanks`,
+    from: 'John Doe <john@factory.cn>',
+    receivedAt: new Date().toISOString(),
+  },
+];

--- a/src/bids/store.ts
+++ b/src/bids/store.ts
@@ -1,0 +1,301 @@
+/**
+ * @file store.ts
+ * @description Zustand store for Bids/Quotes state management
+ * @related-prd Issue #26 - Email ingestion for manufacturer quotes
+ * @author Ralph (AI Agent)
+ * @created 2026-01-23
+ */
+
+import { create } from 'zustand';
+import type {
+  ManufacturerQuote,
+  BidStatus,
+  ParsedField,
+  ParseConfidence,
+} from './types';
+import { parseQuoteEmail, type EmailInput } from './emailParser';
+import { mockQuotes } from './mockData';
+
+interface BidsState {
+  // Data
+  quotes: ManufacturerQuote[];
+  
+  // UI State
+  selectedQuoteId: string | null;
+  filterStatus: BidStatus | 'all';
+  searchTerm: string;
+  
+  // Actions
+  // eslint-disable-next-line no-unused-vars
+  importFromEmail: (email: EmailInput) => ManufacturerQuote;
+  // eslint-disable-next-line no-unused-vars
+  importMultipleEmails: (emails: EmailInput[]) => ManufacturerQuote[];
+  updateQuote: (id: string, updates: Partial<ManufacturerQuote>) => void;
+  updateParsedField: <T>(
+    quoteId: string,
+    fieldName: keyof ManufacturerQuote,
+    value: T,
+    confidence?: ParseConfidence
+  ) => void;
+  deleteQuote: (id: string) => void;
+  setSelectedQuote: (id: string | null) => void;
+  setFilterStatus: (status: BidStatus | 'all') => void;
+  setSearchTerm: (term: string) => void;
+  
+  // Status management
+  markAsReviewed: (id: string, reviewedBy: string) => void;
+  acceptQuote: (id: string) => void;
+  rejectQuote: (id: string, reason?: string) => void;
+  
+  // Computed / Getters
+  getQuoteById: (id: string) => ManufacturerQuote | undefined;
+  getFilteredQuotes: () => ManufacturerQuote[];
+  getQuotesBySupplier: (supplierId: string) => ManufacturerQuote[];
+  getQuoteStats: () => {
+    total: number;
+    byStatus: Record<BidStatus, number>;
+    avgConfidence: number;
+  };
+}
+
+function generateId(): string {
+  return `bid-${Date.now().toString(36)}-${Math.random().toString(36).substr(2, 9)}`;
+}
+
+/**
+ * Calculate overall confidence from parsed fields
+ */
+function recalculateConfidence(quote: ManufacturerQuote): ParseConfidence {
+  const fields = [
+    quote.unitCost?.confidence,
+    quote.moq?.confidence,
+    quote.leadTimeDays?.confidence,
+    quote.paymentTerms?.confidence,
+  ].filter(Boolean) as ParseConfidence[];
+  
+  if (fields.length === 0) return 'low';
+  
+  const scores = { high: 3, medium: 2, low: 1, manual: 3 };
+  const avgScore = fields.reduce((sum, c) => sum + scores[c], 0) / fields.length;
+  
+  if (avgScore >= 2.5) return 'high';
+  if (avgScore >= 1.5) return 'medium';
+  return 'low';
+}
+
+export const useBidsStore = create<BidsState>((set, get) => ({
+  // Initial data
+  quotes: mockQuotes,
+  selectedQuoteId: null,
+  filterStatus: 'all',
+  searchTerm: '',
+  
+  // Import from email
+  importFromEmail: (email: EmailInput) => {
+    const result = parseQuoteEmail(email);
+    const now = Date.now();
+    
+    const newQuote: ManufacturerQuote = {
+      id: generateId(),
+      supplierId: undefined,
+      supplierName: result.quote.supplierName || 'Unknown Supplier',
+      supplierEmail: result.quote.supplierEmail || email.from,
+      unitCost: result.quote.unitCost || { value: null, confidence: 'low', originalText: '', manuallyEdited: false },
+      moq: result.quote.moq || { value: null, confidence: 'low', originalText: '', manuallyEdited: false },
+      leadTimeDays: result.quote.leadTimeDays || { value: null, confidence: 'low', originalText: '', manuallyEdited: false },
+      toolingCosts: result.quote.toolingCosts || { value: null, confidence: 'low', originalText: '', manuallyEdited: false },
+      paymentTerms: result.quote.paymentTerms || { value: null, confidence: 'low', originalText: '', manuallyEdited: false },
+      currency: result.quote.currency || 'USD',
+      productDescription: result.quote.productDescription || email.subject,
+      validUntil: result.quote.validUntil,
+      emailSubject: email.subject,
+      emailBody: email.body,
+      emailReceivedAt: email.receivedAt,
+      emailFrom: email.from,
+      status: 'parsed',
+      overallConfidence: result.quote.overallConfidence || 'low',
+      notes: result.warnings.length > 0 ? `Parsing warnings:\n${result.warnings.join('\n')}` : '',
+      createdAt: now,
+      updatedAt: now,
+    };
+    
+    set((state) => ({
+      quotes: [...state.quotes, newQuote],
+    }));
+    
+    return newQuote;
+  },
+  
+  importMultipleEmails: (emails: EmailInput[]) => {
+    const newQuotes: ManufacturerQuote[] = [];
+    const { importFromEmail } = get();
+    
+    for (const email of emails) {
+      newQuotes.push(importFromEmail(email));
+    }
+    
+    return newQuotes;
+  },
+  
+  updateQuote: (id: string, updates: Partial<ManufacturerQuote>) => {
+    set((state) => ({
+      quotes: state.quotes.map((q) =>
+        q.id === id
+          ? { ...q, ...updates, updatedAt: Date.now() }
+          : q
+      ),
+    }));
+  },
+  
+  updateParsedField: <T>(
+    quoteId: string,
+    fieldName: keyof ManufacturerQuote,
+    value: T,
+    confidence: ParseConfidence = 'manual'
+  ) => {
+    set((state) => {
+      const updatedQuotes = state.quotes.map((q) => {
+        if (q.id !== quoteId) return q;
+        
+        const existingField = q[fieldName] as ParsedField<T> | undefined;
+        const updatedField: ParsedField<T> = {
+          value,
+          confidence,
+          originalText: existingField?.originalText || '',
+          manuallyEdited: true,
+        };
+        
+        const updatedQuote = {
+          ...q,
+          [fieldName]: updatedField,
+          updatedAt: Date.now(),
+        };
+        
+        // Recalculate overall confidence
+        updatedQuote.overallConfidence = recalculateConfidence(updatedQuote);
+        
+        return updatedQuote;
+      });
+      
+      return { quotes: updatedQuotes };
+    });
+  },
+  
+  deleteQuote: (id: string) => {
+    set((state) => ({
+      quotes: state.quotes.filter((q) => q.id !== id),
+      selectedQuoteId: state.selectedQuoteId === id ? null : state.selectedQuoteId,
+    }));
+  },
+  
+  setSelectedQuote: (id: string | null) => {
+    set({ selectedQuoteId: id });
+  },
+  
+  setFilterStatus: (status: BidStatus | 'all') => {
+    set({ filterStatus: status });
+  },
+  
+  setSearchTerm: (term: string) => {
+    set({ searchTerm: term });
+  },
+  
+  markAsReviewed: (id: string, reviewedBy: string) => {
+    set((state) => ({
+      quotes: state.quotes.map((q) =>
+        q.id === id
+          ? {
+              ...q,
+              status: 'reviewed' as BidStatus,
+              reviewedBy,
+              reviewedAt: Date.now(),
+              updatedAt: Date.now(),
+            }
+          : q
+      ),
+    }));
+  },
+  
+  acceptQuote: (id: string) => {
+    set((state) => ({
+      quotes: state.quotes.map((q) =>
+        q.id === id
+          ? { ...q, status: 'accepted' as BidStatus, updatedAt: Date.now() }
+          : q
+      ),
+    }));
+  },
+  
+  rejectQuote: (id: string, reason?: string) => {
+    set((state) => ({
+      quotes: state.quotes.map((q) =>
+        q.id === id
+          ? {
+              ...q,
+              status: 'rejected' as BidStatus,
+              notes: reason ? `${q.notes}\n\nRejection reason: ${reason}` : q.notes,
+              updatedAt: Date.now(),
+            }
+          : q
+      ),
+    }));
+  },
+  
+  getQuoteById: (id: string) => {
+    return get().quotes.find((q) => q.id === id);
+  },
+  
+  getFilteredQuotes: () => {
+    const { quotes, filterStatus, searchTerm } = get();
+    
+    return quotes.filter((q) => {
+      // Status filter
+      if (filterStatus !== 'all' && q.status !== filterStatus) {
+        return false;
+      }
+      
+      // Search filter
+      if (searchTerm) {
+        const term = searchTerm.toLowerCase();
+        return (
+          q.supplierName.toLowerCase().includes(term) ||
+          q.supplierEmail.toLowerCase().includes(term) ||
+          q.productDescription.toLowerCase().includes(term) ||
+          q.emailSubject.toLowerCase().includes(term)
+        );
+      }
+      
+      return true;
+    });
+  },
+  
+  getQuotesBySupplier: (supplierId: string) => {
+    return get().quotes.filter((q) => q.supplierId === supplierId);
+  },
+  
+  getQuoteStats: () => {
+    const quotes = get().quotes;
+    const byStatus: Record<BidStatus, number> = {
+      draft: 0,
+      parsed: 0,
+      reviewed: 0,
+      accepted: 0,
+      rejected: 0,
+      expired: 0,
+    };
+    
+    const confidenceScores = { high: 3, medium: 2, low: 1, manual: 3 };
+    let totalConfidence = 0;
+    
+    for (const q of quotes) {
+      byStatus[q.status]++;
+      totalConfidence += confidenceScores[q.overallConfidence];
+    }
+    
+    return {
+      total: quotes.length,
+      byStatus,
+      avgConfidence: quotes.length > 0 ? totalConfidence / quotes.length : 0,
+    };
+  },
+}));

--- a/src/bids/types.ts
+++ b/src/bids/types.ts
@@ -1,0 +1,168 @@
+/**
+ * @file types.ts
+ * @description Type definitions for Bids module - Manufacturer quote parsing from emails
+ * @related-prd Issue #26 - Email ingestion for manufacturer quotes
+ * @author Ralph (AI Agent)
+ * @created 2026-01-23
+ */
+
+export type BidStatus = 'draft' | 'parsed' | 'reviewed' | 'accepted' | 'rejected' | 'expired';
+export type ParseConfidence = 'high' | 'medium' | 'low' | 'manual';
+
+/**
+ * Represents a single parsed field from an email with confidence tracking
+ */
+export interface ParsedField<T> {
+  value: T | null;
+  confidence: ParseConfidence;
+  originalText: string; // The raw text that was parsed
+  manuallyEdited: boolean;
+}
+
+/**
+ * Payment terms structure
+ */
+export interface PaymentTerms {
+  type: string; // e.g., "Net 30", "50% deposit, 50% on shipment"
+  depositPercent?: number;
+  netDays?: number;
+  notes?: string;
+}
+
+/**
+ * Tooling cost breakdown
+ */
+export interface ToolingCost {
+  moldCost: number;
+  setupCost: number;
+  otherCosts: number;
+  total: number;
+  amortizedPerUnit?: number;
+  notes?: string;
+}
+
+/**
+ * Core quote data extracted from manufacturer email
+ */
+export interface ManufacturerQuote {
+  id: string;
+  supplierId?: string; // Link to existing supplier
+  supplierName: string;
+  supplierEmail: string;
+  
+  // Parsed fields with confidence tracking
+  unitCost: ParsedField<number>;
+  moq: ParsedField<number>; // Minimum Order Quantity
+  leadTimeDays: ParsedField<number>;
+  toolingCosts: ParsedField<ToolingCost>;
+  paymentTerms: ParsedField<PaymentTerms>;
+  
+  // Additional parsed data
+  currency: string;
+  productDescription: string;
+  validUntil?: string; // Quote expiration date
+  
+  // Original email data
+  emailSubject: string;
+  emailBody: string;
+  emailReceivedAt: string;
+  emailFrom: string;
+  
+  // Metadata
+  status: BidStatus;
+  overallConfidence: ParseConfidence;
+  notes: string;
+  createdAt: number;
+  updatedAt: number;
+  reviewedBy?: string;
+  reviewedAt?: number;
+}
+
+/**
+ * Tier pricing structure (common in manufacturer quotes)
+ */
+export interface PricingTier {
+  minQuantity: number;
+  maxQuantity?: number;
+  unitPrice: number;
+}
+
+/**
+ * Extended quote with tier pricing
+ */
+export interface ManufacturerQuoteWithTiers extends ManufacturerQuote {
+  pricingTiers: ParsedField<PricingTier[]>;
+}
+
+/**
+ * Input for parsing an email
+ */
+export interface EmailInput {
+  subject: string;
+  body: string;
+  from: string;
+  receivedAt: string;
+}
+
+/**
+ * Parser result with all extracted fields
+ */
+export interface ParseResult {
+  success: boolean;
+  quote: Partial<ManufacturerQuote>;
+  errors: string[];
+  warnings: string[];
+}
+
+// Status labels and colors for UI
+export const BID_STATUS_LABELS: Record<BidStatus, string> = {
+  draft: 'Draft',
+  parsed: 'Parsed',
+  reviewed: 'Reviewed',
+  accepted: 'Accepted',
+  rejected: 'Rejected',
+  expired: 'Expired',
+};
+
+export const BID_STATUS_COLORS: Record<BidStatus, string> = {
+  draft: 'bg-gray-100 text-gray-800',
+  parsed: 'bg-yellow-100 text-yellow-800',
+  reviewed: 'bg-blue-100 text-blue-800',
+  accepted: 'bg-green-100 text-green-800',
+  rejected: 'bg-red-100 text-red-800',
+  expired: 'bg-orange-100 text-orange-800',
+};
+
+export const CONFIDENCE_COLORS: Record<ParseConfidence, string> = {
+  high: 'text-green-600',
+  medium: 'text-yellow-600',
+  low: 'text-red-600',
+  manual: 'text-blue-600',
+};
+
+export const CONFIDENCE_LABELS: Record<ParseConfidence, string> = {
+  high: 'High Confidence',
+  medium: 'Medium Confidence',
+  low: 'Low Confidence',
+  manual: 'Manually Entered',
+};
+
+// Default values for new quotes
+export const DEFAULT_PARSED_FIELD = <T>(value: T | null = null): ParsedField<T> => ({
+  value,
+  confidence: 'low',
+  originalText: '',
+  manuallyEdited: false,
+});
+
+export const DEFAULT_TOOLING_COST: ToolingCost = {
+  moldCost: 0,
+  setupCost: 0,
+  otherCosts: 0,
+  total: 0,
+};
+
+export const DEFAULT_PAYMENT_TERMS: PaymentTerms = {
+  type: 'Net 30',
+  netDays: 30,
+};


### PR DESCRIPTION
## Summary
Implements Issue #26: Email ingestion for manufacturer quotes

## Changes
### New Module: `src/bids/`

**Email Parser Service** (`emailParser.ts`)
- Regex-based extraction for manufacturer quote data:
  - Unit cost ($X.XX, USD X.XX, X.XX/unit formats)
  - MOQ (minimum order quantity)
  - Lead time (days/weeks with conversion)
  - Tooling costs (mold, setup, other)
  - Payment terms (Net 30, deposit %, etc.)
- Confidence scoring (high/medium/low) based on pattern match quality
- Currency detection (USD, EUR, GBP, CNY, JPY)
- Supplier name/email extraction from sender

**Types** (`types.ts`)
- `ManufacturerQuote` - Full quote data with parsed fields
- `ParsedField<T>` - Wraps values with confidence and original text
- `ToolingCost`, `PaymentTerms` - Structured cost data
- Status enums and UI helper constants

**UI Components**
- `BidList.tsx` - Main list view with:
  - Status filter cards (draft/parsed/reviewed/accepted/rejected/expired)
  - Search by supplier/product/email
  - Email import modal for pasting quotes
  - Confidence-colored values
- `BidDetail.tsx` - Detail/correction view with:
  - Click-to-edit fields showing original parsed text
  - Confidence indicators per field
  - Original email display for reference
  - Status workflow buttons

**Store** (`store.ts`)
- Zustand state management
- Email import with automatic parsing
- Field-level updates with confidence recalculation
- Quote lifecycle management

**Tests** (`__tests__/emailParser.test.ts`)
- 24 unit tests covering all extraction patterns
- Edge cases for missing data, varied formats

### Routes Added
- `/bids` - Quote list with stats dashboard
- `/bids/:id` - Quote detail with correction UI

## Testing
```bash
npm run test -- src/bids --run
# 24 tests pass
```

## Screenshots
_The UI provides a list view with import modal and detail view with inline editing._

## Related Issues
Closes #26