### PR TITLE
feat(dcf): Free Cash Flow Projections - Issue #21

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,8 +10,9 @@ import { IncomeStatement, BalanceSheet, CashFlowStatement } from './financials'
 import { Inventory } from './inventory'
 import { Pricing } from './pricing'
 import { AllAssumptions } from './assumptions'
-import { Valuation, ValuationSummary } from './valuation'
+import { Valuation, ValuationSummary, FCFProjections } from './valuation'
 import { InvestorCohorts } from './investors'
+import { RaiseScenarioMatrix } from './capital'
 import { AuthProvider, ProtectedRoute, LoginPage, RoleSelector, PermissionGate } from './auth'
 import { SupplierList, SupplierDetail, PurchaseOrderList, PurchaseOrderDetail, Receiving, VendorComparison } from './supply-chain'
 import { BidList, BidDetail } from './bids'
@@ -118,7 +119,7 @@ function App() {
               <ProtectedRoute>
                 <PermissionGate permission="view:capital" fallback={<AccessDenied />}>
                   <Layout title="Capital">
-                    <PlaceholderPage title="Capital" />
+                    <RaiseScenarioMatrix />
                   </Layout>
                 </PermissionGate>
               </ProtectedRoute>
@@ -155,6 +156,18 @@ function App() {
                 <PermissionGate permission="view:dcf" fallback={<AccessDenied />}>
                   <Layout title="DCF Valuation">
                     <Valuation />
+                  </Layout>
+                </PermissionGate>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/valuation/fcf"
+            element={
+              <ProtectedRoute>
+                <PermissionGate permission="view:dcf" fallback={<AccessDenied />}>
+                  <Layout title="FCF Projections">
+                    <FCFProjections />
                   </Layout>
                 </PermissionGate>
               </ProtectedRoute>

--- a/src/models/dcf/__tests__/fcfProjections.test.ts
+++ b/src/models/dcf/__tests__/fcfProjections.test.ts
@@ -1,0 +1,275 @@
+import {
+  projectFCFByScenario,
+  projectFCFAllScenarios,
+  getFCFComponentBreakdown,
+  formatFCFCurrency,
+  formatFCFPercent,
+  type FCFYearComponents,
+  type FCFProjectionResult,
+} from '../fcfProjections';
+import { DEFAULT_ASSUMPTIONS } from '../../assumptions/defaults';
+
+describe('FCF Projections', () => {
+  describe('projectFCFByScenario', () => {
+    it('should calculate FCF for base scenario over 5 years', () => {
+      const result = projectFCFByScenario('base', DEFAULT_ASSUMPTIONS, 5);
+
+      expect(result.scenario).toBe('base');
+      expect(result.scenarioLabel).toBe('Base');
+      expect(result.years).toHaveLength(5);
+    });
+
+    it('should include all FCF components for each year', () => {
+      const result = projectFCFByScenario('base', DEFAULT_ASSUMPTIONS, 5);
+      const year1 = result.years[0];
+
+      // Check all required fields are present
+      expect(year1).toHaveProperty('year');
+      expect(year1).toHaveProperty('units');
+      expect(year1).toHaveProperty('revenue');
+      expect(year1).toHaveProperty('cogs');
+      expect(year1).toHaveProperty('grossProfit');
+      expect(year1).toHaveProperty('ebitda');
+      expect(year1).toHaveProperty('taxes');
+      expect(year1).toHaveProperty('capex');
+      expect(year1).toHaveProperty('workingCapitalChange');
+      expect(year1).toHaveProperty('fcf');
+      expect(year1).toHaveProperty('discountFactor');
+      expect(year1).toHaveProperty('presentValue');
+    });
+
+    it('should verify FCF formula: FCF = NOPAT + D&A - CapEx - ΔWC', () => {
+      const result = projectFCFByScenario('base', DEFAULT_ASSUMPTIONS, 5);
+
+      for (const year of result.years) {
+        const expectedFCF = year.nopat + year.depreciation - year.capex - year.workingCapitalChange;
+        expect(year.fcf).toBeCloseTo(expectedFCF, 2);
+      }
+    });
+
+    it('should calculate cumulative FCF correctly', () => {
+      const result = projectFCFByScenario('base', DEFAULT_ASSUMPTIONS, 5);
+
+      let cumulativeFCF = 0;
+      for (const year of result.years) {
+        cumulativeFCF += year.fcf;
+        expect(year.cumulativeFCF).toBeCloseTo(cumulativeFCF, 2);
+      }
+    });
+
+    it('should calculate present value with discount factor', () => {
+      const result = projectFCFByScenario('base', DEFAULT_ASSUMPTIONS, 5);
+      const discountRate = DEFAULT_ASSUMPTIONS.corporate.discountRate;
+
+      for (const year of result.years) {
+        const expectedDF = 1 / Math.pow(1 + discountRate, year.year);
+        expect(year.discountFactor).toBeCloseTo(expectedDF, 4);
+        expect(year.presentValue).toBeCloseTo(year.fcf * year.discountFactor, 2);
+      }
+    });
+
+    it('should calculate total revenue correctly', () => {
+      const result = projectFCFByScenario('base', DEFAULT_ASSUMPTIONS, 5);
+      const sumRevenue = result.years.reduce((sum, y) => sum + y.revenue, 0);
+      expect(result.totalRevenue).toBeCloseTo(sumRevenue, 2);
+    });
+
+    it('should calculate total PV correctly', () => {
+      const result = projectFCFByScenario('base', DEFAULT_ASSUMPTIONS, 5);
+      const sumPV = result.years.reduce((sum, y) => sum + y.presentValue, 0);
+      expect(result.totalPV).toBeCloseTo(sumPV, 2);
+    });
+
+    it('should handle different projection years', () => {
+      const result5 = projectFCFByScenario('base', DEFAULT_ASSUMPTIONS, 5);
+      const result10 = projectFCFByScenario('base', DEFAULT_ASSUMPTIONS, 10);
+
+      expect(result5.years).toHaveLength(5);
+      expect(result10.years).toHaveLength(10);
+
+      // First 5 years should be identical
+      for (let i = 0; i < 5; i++) {
+        expect(result5.years[i].fcf).toBeCloseTo(result10.years[i].fcf, 2);
+      }
+    });
+
+    it('should identify break-even year when cumulative FCF turns positive', () => {
+      const result = projectFCFByScenario('base', DEFAULT_ASSUMPTIONS, 10);
+
+      if (result.breakEvenYear !== null) {
+        // Cumulative FCF should be positive at break-even year
+        const breakEvenYearData = result.years[result.breakEvenYear - 1];
+        expect(breakEvenYearData.cumulativeFCF).toBeGreaterThan(0);
+
+        // And negative in the year before (if not year 1)
+        if (result.breakEvenYear > 1) {
+          const prevYearData = result.years[result.breakEvenYear - 2];
+          expect(prevYearData.cumulativeFCF).toBeLessThanOrEqual(0);
+        }
+      }
+    });
+  });
+
+  describe('projectFCFAllScenarios', () => {
+    it('should calculate FCF for all 5 scenarios', () => {
+      const result = projectFCFAllScenarios(DEFAULT_ASSUMPTIONS, 5);
+
+      expect(result.scenarioOrder).toEqual(['max', 'upside', 'base', 'downside', 'min']);
+      expect(Object.keys(result.scenarios)).toHaveLength(5);
+    });
+
+    it('should identify best and worst cases correctly', () => {
+      const result = projectFCFAllScenarios(DEFAULT_ASSUMPTIONS, 5);
+
+      // Best case should have highest FCF
+      const allFCFs = result.scenarioOrder.map((s) => result.scenarios[s].totalFCF);
+      expect(result.bestCase.totalFCF).toBe(Math.max(...allFCFs));
+      expect(result.worstCase.totalFCF).toBe(Math.min(...allFCFs));
+    });
+
+    it('should have max scenario produce higher FCF than min scenario', () => {
+      const result = projectFCFAllScenarios(DEFAULT_ASSUMPTIONS, 5);
+
+      expect(result.scenarios['max'].totalFCF).toBeGreaterThan(result.scenarios['min'].totalFCF);
+    });
+
+    it('should have base case correctly identified', () => {
+      const result = projectFCFAllScenarios(DEFAULT_ASSUMPTIONS, 5);
+
+      expect(result.baseCase.scenario).toBe('base');
+      expect(result.baseCase.totalFCF).toBe(result.scenarios['base'].totalFCF);
+    });
+  });
+
+  describe('getFCFComponentBreakdown', () => {
+    it('should return breakdown for each year', () => {
+      const fcfResult = projectFCFByScenario('base', DEFAULT_ASSUMPTIONS, 5);
+      const breakdown = getFCFComponentBreakdown(fcfResult);
+
+      expect(breakdown).toHaveLength(5);
+    });
+
+    it('should have negative values for uses of cash', () => {
+      const fcfResult = projectFCFByScenario('base', DEFAULT_ASSUMPTIONS, 5);
+      const breakdown = getFCFComponentBreakdown(fcfResult);
+
+      for (const year of breakdown) {
+        // Taxes, CapEx, WC increase should be negative in breakdown
+        expect(year.taxes).toBeLessThanOrEqual(0);
+        expect(year.capex).toBeLessThanOrEqual(0);
+        // WC change can be positive (release) or negative (use)
+      }
+    });
+
+    it('should match original data', () => {
+      const fcfResult = projectFCFByScenario('base', DEFAULT_ASSUMPTIONS, 5);
+      const breakdown = getFCFComponentBreakdown(fcfResult);
+
+      for (let i = 0; i < 5; i++) {
+        expect(breakdown[i].year).toBe(fcfResult.years[i].year);
+        expect(breakdown[i].ebitda).toBe(fcfResult.years[i].ebitda);
+        expect(breakdown[i].fcf).toBe(fcfResult.years[i].fcf);
+      }
+    });
+  });
+
+  describe('formatFCFCurrency', () => {
+    it('should format billions correctly', () => {
+      expect(formatFCFCurrency(1_500_000_000)).toBe('$1.50B');
+    });
+
+    it('should format millions correctly', () => {
+      expect(formatFCFCurrency(2_500_000)).toBe('$2.50M');
+    });
+
+    it('should format thousands correctly', () => {
+      expect(formatFCFCurrency(150_000)).toBe('$150K');
+    });
+
+    it('should format small values correctly', () => {
+      expect(formatFCFCurrency(500)).toBe('$500');
+    });
+
+    it('should handle negative values', () => {
+      expect(formatFCFCurrency(-1_500_000)).toBe('-$1.50M');
+    });
+
+    it('should format non-compact values', () => {
+      const result = formatFCFCurrency(1_234_567, false);
+      expect(result).toBe('$1,234,567');
+    });
+  });
+
+  describe('formatFCFPercent', () => {
+    it('should format positive percentages', () => {
+      expect(formatFCFPercent(25.5)).toBe('25.5%');
+    });
+
+    it('should format negative percentages', () => {
+      expect(formatFCFPercent(-10.2)).toBe('-10.2%');
+    });
+
+    it('should format zero', () => {
+      expect(formatFCFPercent(0)).toBe('0.0%');
+    });
+  });
+
+  describe('margin calculations', () => {
+    it('should calculate correct gross margin percentage', () => {
+      const result = projectFCFByScenario('base', DEFAULT_ASSUMPTIONS, 5);
+
+      for (const year of result.years) {
+        if (year.revenue > 0) {
+          const expectedMargin = (year.grossProfit / year.revenue) * 100;
+          expect(year.grossMarginPct).toBeCloseTo(expectedMargin, 2);
+        }
+      }
+    });
+
+    it('should calculate correct EBITDA margin percentage', () => {
+      const result = projectFCFByScenario('base', DEFAULT_ASSUMPTIONS, 5);
+
+      for (const year of result.years) {
+        if (year.revenue > 0) {
+          const expectedMargin = (year.ebitda / year.revenue) * 100;
+          expect(year.ebitdaMarginPct).toBeCloseTo(expectedMargin, 2);
+        }
+      }
+    });
+
+    it('should calculate correct FCF margin percentage', () => {
+      const result = projectFCFByScenario('base', DEFAULT_ASSUMPTIONS, 5);
+
+      for (const year of result.years) {
+        if (year.revenue > 0) {
+          const expectedMargin = (year.fcf / year.revenue) * 100;
+          expect(year.fcfMarginPct).toBeCloseTo(expectedMargin, 2);
+        }
+      }
+    });
+  });
+
+  describe('tax calculations', () => {
+    it('should only apply taxes when EBIT is positive', () => {
+      const result = projectFCFByScenario('base', DEFAULT_ASSUMPTIONS, 5);
+
+      for (const year of result.years) {
+        if (year.ebit <= 0) {
+          expect(year.taxes).toBe(0);
+        } else {
+          const expectedTax = year.ebit * year.taxRate;
+          expect(year.taxes).toBeCloseTo(expectedTax, 2);
+        }
+      }
+    });
+
+    it('should calculate NOPAT correctly', () => {
+      const result = projectFCFByScenario('base', DEFAULT_ASSUMPTIONS, 5);
+
+      for (const year of result.years) {
+        const expectedNOPAT = year.ebit - year.taxes;
+        expect(year.nopat).toBeCloseTo(expectedNOPAT, 2);
+      }
+    });
+  });
+});

--- a/src/models/dcf/fcfProjections.ts
+++ b/src/models/dcf/fcfProjections.ts
@@ -1,0 +1,445 @@
+/**
+ * FCF Projection Engine
+ * 
+ * Projects Free Cash Flow by scenario for 5-10 years with component breakdown.
+ * 
+ * Formula: FCF = EBIT(1-t) + D&A - CapEx - ΔWorkingCapital
+ *          or  FCF = EBITDA - Taxes - CapEx - ΔWorkingCapital
+ */
+
+import { getAnnualProjections } from '../adoption/projections';
+import type { AllAssumptions } from '../assumptions/types';
+import { calculateDiscountFactor } from './npv';
+
+/**
+ * FCF component breakdown for a single year
+ */
+export interface FCFYearComponents {
+  year: number;
+  yearLabel: string;
+  
+  // P&L components
+  units: number;
+  revenue: number;
+  cogs: number;
+  grossProfit: number;
+  grossMarginPct: number;
+  
+  marketing: number;
+  gna: number;
+  
+  ebitda: number;
+  ebitdaMarginPct: number;
+  
+  depreciation: number;
+  ebit: number;
+  ebitMarginPct: number;
+  
+  // FCF components
+  taxes: number;
+  taxRate: number;
+  nopat: number; // EBIT * (1 - tax rate)
+  
+  capex: number;
+  workingCapital: number;
+  workingCapitalChange: number;
+  
+  // Final FCF
+  fcf: number;
+  fcfMarginPct: number;
+  
+  // Discounted values
+  discountFactor: number;
+  presentValue: number;
+  
+  // Cumulative
+  cumulativeFCF: number;
+  cumulativePV: number;
+}
+
+/**
+ * Complete FCF projection result for a scenario
+ */
+export interface FCFProjectionResult {
+  scenario: string;
+  scenarioLabel: string;
+  years: FCFYearComponents[];
+  
+  // Summary metrics
+  totalFCF: number;
+  totalPV: number;
+  avgFCFMargin: number;
+  fcfCAGR: number; // Compound annual growth rate
+  
+  // Component totals
+  totalRevenue: number;
+  totalEBITDA: number;
+  totalCapex: number;
+  totalWCChange: number;
+  totalTaxes: number;
+  
+  // Year-over-year growth rates
+  fcfGrowthRates: number[];
+  
+  // First positive FCF year
+  breakEvenYear: number | null;
+}
+
+/**
+ * All scenarios comparison
+ */
+export interface FCFScenarioComparison {
+  scenarios: Record<string, FCFProjectionResult>;
+  scenarioOrder: string[];
+  
+  // Cross-scenario metrics
+  bestCase: {
+    scenario: string;
+    totalFCF: number;
+    totalPV: number;
+  };
+  worstCase: {
+    scenario: string;
+    totalFCF: number;
+    totalPV: number;
+  };
+  baseCase: {
+    scenario: string;
+    totalFCF: number;
+    totalPV: number;
+  };
+}
+
+const SCENARIO_LABELS: Record<string, string> = {
+  max: 'Maximum',
+  upside: 'Upside',
+  base: 'Base',
+  downside: 'Downside',
+  min: 'Minimum',
+};
+
+/**
+ * Calculate COGS for a given year with cost reduction
+ */
+function calculateCOGS(
+  units: number,
+  unitCost: number,
+  shippingPerUnit: number,
+  costReductionPerYear: number,
+  yearIndex: number
+): number {
+  const effectiveUnitCost = unitCost * Math.pow(1 - costReductionPerYear, yearIndex);
+  return units * (effectiveUnitCost + shippingPerUnit);
+}
+
+/**
+ * Calculate Marketing spend
+ */
+function calculateMarketing(
+  revenue: number,
+  baseBudget: number,
+  percentOfRevenue: number
+): number {
+  return baseBudget + revenue * percentOfRevenue;
+}
+
+/**
+ * Calculate G&A with salary growth
+ */
+function calculateGNA(
+  baseHeadcount: number,
+  avgSalary: number,
+  salaryGrowthRate: number,
+  benefitsMultiplier: number,
+  officeAndOps: number,
+  yearIndex: number
+): number {
+  const effectiveSalary = avgSalary * Math.pow(1 + salaryGrowthRate, yearIndex);
+  const personnelCost = baseHeadcount * effectiveSalary * benefitsMultiplier;
+  return personnelCost + officeAndOps;
+}
+
+/**
+ * Calculate CapEx with growth
+ */
+function calculateCapex(
+  capexYear1: number,
+  capexGrowthRate: number,
+  yearIndex: number
+): number {
+  return capexYear1 * Math.pow(1 + capexGrowthRate, yearIndex);
+}
+
+/**
+ * Project FCF for a single scenario
+ */
+export function projectFCFByScenario(
+  scenario: string,
+  assumptions: AllAssumptions,
+  projectionYears?: number
+): FCFProjectionResult {
+  const { revenue, cogs, marketing, gna, capital, corporate } = assumptions;
+  const years = projectionYears ?? corporate.projectionYears;
+  const baseYear = 2025;
+
+  // Get unit projections from adoption model
+  const unitProjections = getAnnualProjections(scenario, baseYear, years);
+
+  const yearComponents: FCFYearComponents[] = [];
+  let previousWorkingCapital = 0;
+  let cumulativeFCF = 0;
+  let cumulativePV = 0;
+
+  // Totals
+  let totalRevenue = 0;
+  let totalEBITDA = 0;
+  let totalCapex = 0;
+  let totalWCChange = 0;
+  let totalTaxes = 0;
+  let totalFCF = 0;
+
+  const fcfGrowthRates: number[] = [];
+  let breakEvenYear: number | null = null;
+
+  for (let i = 0; i < years; i++) {
+    const yearNumber = i + 1;
+    const units = unitProjections[i];
+
+    // Revenue calculation
+    const effectivePrice = revenue.pricePerUnit * Math.pow(1 + revenue.annualPriceIncrease, i);
+    const grossRevenue = units * effectivePrice;
+    const netRevenue = grossRevenue * (1 - revenue.discountRate);
+
+    // COGS
+    const yearCOGS = calculateCOGS(
+      units,
+      cogs.unitCost,
+      cogs.shippingPerUnit,
+      cogs.costReductionPerYear,
+      i
+    );
+
+    // Gross profit
+    const grossProfit = netRevenue - yearCOGS;
+    const grossMarginPct = netRevenue > 0 ? (grossProfit / netRevenue) * 100 : 0;
+
+    // Operating expenses
+    const yearMarketing = calculateMarketing(
+      netRevenue,
+      marketing.baseBudget,
+      marketing.percentOfRevenue
+    );
+
+    const yearGNA = calculateGNA(
+      gna.baseHeadcount,
+      gna.avgSalary,
+      gna.salaryGrowthRate,
+      gna.benefitsMultiplier,
+      gna.officeAndOps,
+      i
+    );
+
+    // EBITDA
+    const ebitda = grossProfit - yearMarketing - yearGNA;
+    const ebitdaMarginPct = netRevenue > 0 ? (ebitda / netRevenue) * 100 : 0;
+
+    // Depreciation (simplified - could be enhanced)
+    const depreciation = 0;
+
+    // EBIT
+    const ebit = ebitda - depreciation;
+    const ebitMarginPct = netRevenue > 0 ? (ebit / netRevenue) * 100 : 0;
+
+    // Taxes (only on positive EBIT)
+    const taxes = ebit > 0 ? ebit * corporate.taxRate : 0;
+
+    // NOPAT = EBIT * (1 - t)
+    const nopat = ebit - taxes;
+
+    // CapEx
+    const capex = calculateCapex(capital.capexYear1, capital.capexGrowthRate, i);
+
+    // Working capital
+    const workingCapital = netRevenue * capital.workingCapitalPercent;
+    const workingCapitalChange = workingCapital - previousWorkingCapital;
+    previousWorkingCapital = workingCapital;
+
+    // FCF = NOPAT + D&A - CapEx - ΔWC
+    // Equivalent to: EBITDA - Taxes - CapEx - ΔWC (when D&A = 0)
+    const fcf = nopat + depreciation - capex - workingCapitalChange;
+    const fcfMarginPct = netRevenue > 0 ? (fcf / netRevenue) * 100 : 0;
+
+    // Discount factor and PV
+    const discountFactor = calculateDiscountFactor(corporate.discountRate, yearNumber);
+    const presentValue = fcf * discountFactor;
+
+    // Cumulatives
+    cumulativeFCF += fcf;
+    cumulativePV += presentValue;
+
+    // Track break-even
+    if (breakEvenYear === null && cumulativeFCF > 0) {
+      breakEvenYear = yearNumber;
+    }
+
+    // Growth rate
+    if (i > 0 && yearComponents[i - 1].fcf !== 0) {
+      const growthRate = (fcf - yearComponents[i - 1].fcf) / Math.abs(yearComponents[i - 1].fcf);
+      fcfGrowthRates.push(growthRate);
+    }
+
+    // Totals
+    totalRevenue += netRevenue;
+    totalEBITDA += ebitda;
+    totalCapex += capex;
+    totalWCChange += workingCapitalChange;
+    totalTaxes += taxes;
+    totalFCF += fcf;
+
+    yearComponents.push({
+      year: yearNumber,
+      yearLabel: `Year ${yearNumber}`,
+      units,
+      revenue: netRevenue,
+      cogs: yearCOGS,
+      grossProfit,
+      grossMarginPct,
+      marketing: yearMarketing,
+      gna: yearGNA,
+      ebitda,
+      ebitdaMarginPct,
+      depreciation,
+      ebit,
+      ebitMarginPct,
+      taxes,
+      taxRate: corporate.taxRate,
+      nopat,
+      capex,
+      workingCapital,
+      workingCapitalChange,
+      fcf,
+      fcfMarginPct,
+      discountFactor,
+      presentValue,
+      cumulativeFCF,
+      cumulativePV,
+    });
+  }
+
+  // Calculate CAGR
+  const firstFCF = yearComponents[0]?.fcf || 0;
+  const lastFCF = yearComponents[yearComponents.length - 1]?.fcf || 0;
+  let fcfCAGR = 0;
+  if (firstFCF > 0 && lastFCF > 0 && years > 1) {
+    fcfCAGR = Math.pow(lastFCF / firstFCF, 1 / (years - 1)) - 1;
+  }
+
+  // Average FCF margin
+  const avgFCFMargin = totalRevenue > 0 ? (totalFCF / totalRevenue) * 100 : 0;
+
+  return {
+    scenario,
+    scenarioLabel: SCENARIO_LABELS[scenario] || scenario,
+    years: yearComponents,
+    totalFCF,
+    totalPV: cumulativePV,
+    avgFCFMargin,
+    fcfCAGR,
+    totalRevenue,
+    totalEBITDA,
+    totalCapex,
+    totalWCChange,
+    totalTaxes,
+    fcfGrowthRates,
+    breakEvenYear,
+  };
+}
+
+/**
+ * Project FCF for all scenarios
+ */
+export function projectFCFAllScenarios(
+  assumptions: AllAssumptions,
+  projectionYears?: number
+): FCFScenarioComparison {
+  const scenarioOrder = ['max', 'upside', 'base', 'downside', 'min'];
+  const scenarios: Record<string, FCFProjectionResult> = {};
+
+  for (const scenario of scenarioOrder) {
+    scenarios[scenario] = projectFCFByScenario(scenario, assumptions, projectionYears);
+  }
+
+  // Find best, worst, base cases
+  const sortedByFCF = scenarioOrder
+    .map((s) => ({ scenario: s, totalFCF: scenarios[s].totalFCF, totalPV: scenarios[s].totalPV }))
+    .sort((a, b) => b.totalFCF - a.totalFCF);
+
+  return {
+    scenarios,
+    scenarioOrder,
+    bestCase: sortedByFCF[0],
+    worstCase: sortedByFCF[sortedByFCF.length - 1],
+    baseCase: {
+      scenario: 'base',
+      totalFCF: scenarios['base'].totalFCF,
+      totalPV: scenarios['base'].totalPV,
+    },
+  };
+}
+
+/**
+ * Get FCF component breakdown for visualization
+ */
+export interface FCFComponentBreakdown {
+  year: number;
+  yearLabel: string;
+  ebitda: number;
+  taxes: number;
+  capex: number;
+  wcChange: number;
+  fcf: number;
+}
+
+export function getFCFComponentBreakdown(result: FCFProjectionResult): FCFComponentBreakdown[] {
+  return result.years.map((y) => ({
+    year: y.year,
+    yearLabel: y.yearLabel,
+    ebitda: y.ebitda,
+    taxes: -y.taxes, // Negative for waterfall
+    capex: -y.capex, // Negative for waterfall
+    wcChange: -y.workingCapitalChange, // Negative for waterfall (increase uses cash)
+    fcf: y.fcf,
+  }));
+}
+
+/**
+ * Format helpers
+ */
+export function formatFCFCurrency(value: number, compact = true): string {
+  const absValue = Math.abs(value);
+  const sign = value < 0 ? '-' : '';
+
+  if (compact) {
+    if (absValue >= 1_000_000_000) {
+      return `${sign}$${(absValue / 1_000_000_000).toFixed(2)}B`;
+    }
+    if (absValue >= 1_000_000) {
+      return `${sign}$${(absValue / 1_000_000).toFixed(2)}M`;
+    }
+    if (absValue >= 1_000) {
+      return `${sign}$${(absValue / 1_000).toFixed(0)}K`;
+    }
+    return `${sign}$${absValue.toFixed(0)}`;
+  }
+
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+export function formatFCFPercent(value: number): string {
+  return `${value >= 0 ? '' : ''}${value.toFixed(1)}%`;
+}

--- a/src/models/dcf/index.ts
+++ b/src/models/dcf/index.ts
@@ -81,6 +81,22 @@ export {
   getValuationSummary,
 } from './calculator';
 
+// FCF Projections exports
+export {
+  projectFCFByScenario,
+  projectFCFAllScenarios,
+  getFCFComponentBreakdown,
+  formatFCFCurrency,
+  formatFCFPercent,
+} from './fcfProjections';
+
+export type {
+  FCFYearComponents,
+  FCFProjectionResult,
+  FCFScenarioComparison,
+  FCFComponentBreakdown,
+} from './fcfProjections';
+
 // Re-export types namespace for convenience
 import * as types from './types';
 export { types };

--- a/src/valuation/FCFProjections.tsx
+++ b/src/valuation/FCFProjections.tsx
@@ -1,0 +1,598 @@
+/**
+ * FCF Projections Component
+ * 
+ * Displays Free Cash Flow projections by scenario with:
+ * - FCF projection table by year
+ * - Component breakdown chart
+ * - Scenario comparison
+ */
+
+import { useMemo, useState } from 'react';
+import {
+  ComposedChart,
+  Bar,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  ReferenceLine,
+  BarChart,
+  Cell,
+} from 'recharts';
+import { KPICard } from '../components/KPICard';
+import { useAssumptionsStore } from '../stores/assumptionsStore';
+import { useScenarioStore } from '../stores/scenarioStore';
+import {
+  projectFCFByScenario,
+  projectFCFAllScenarios,
+  getFCFComponentBreakdown,
+  formatFCFCurrency,
+  formatFCFPercent,
+  type FCFProjectionResult,
+  type FCFScenarioComparison,
+} from '../models/dcf';
+
+type ScenarioId = 'min' | 'downside' | 'base' | 'upside' | 'max';
+
+const SCENARIO_COLORS: Record<string, string> = {
+  max: '#22c55e',      // green-500
+  upside: '#84cc16',   // lime-500
+  base: '#3b82f6',     // blue-500
+  downside: '#f97316', // orange-500
+  min: '#ef4444',      // red-500
+};
+
+const SCENARIO_BG_COLORS: Record<string, string> = {
+  max: 'bg-green-50',
+  upside: 'bg-lime-50',
+  base: 'bg-blue-50',
+  downside: 'bg-orange-50',
+  min: 'bg-red-50',
+};
+
+export function FCFProjections() {
+  const assumptions = useAssumptionsStore();
+  const { selectedScenarioId, scenarios, selectScenario } = useScenarioStore();
+  const [compareMode, setCompareMode] = useState(false);
+  const [projectionYears, setProjectionYears] = useState(5);
+
+  // Calculate FCF projections
+  const fcfResult = useMemo(
+    () => projectFCFByScenario(selectedScenarioId, assumptions, projectionYears),
+    [selectedScenarioId, assumptions, projectionYears]
+  );
+
+  const allScenarios = useMemo(
+    () => projectFCFAllScenarios(assumptions, projectionYears),
+    [assumptions, projectionYears]
+  );
+
+  const componentBreakdown = useMemo(
+    () => getFCFComponentBreakdown(fcfResult),
+    [fcfResult]
+  );
+
+  const selectedScenario = scenarios.find((s) => s.id === selectedScenarioId);
+
+  return (
+    <div className="space-y-6">
+      {/* Header with Scenario Banner */}
+      {selectedScenario && (
+        <div className={`border rounded-lg px-4 py-3 flex items-center justify-between ${SCENARIO_BG_COLORS[selectedScenarioId]} border-gray-200`}>
+          <div>
+            <p className="text-sm text-gray-800">
+              <span className="font-medium">FCF Projections:</span>{' '}
+              {selectedScenario.name} Scenario — {projectionYears}-Year Forecast
+            </p>
+            <p className="text-xs text-gray-600 mt-1">
+              FCF = EBIT(1-t) + D&A - CapEx - ΔWorking Capital
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <select
+              value={projectionYears}
+              onChange={(e) => setProjectionYears(Number(e.target.value))}
+              className="px-2 py-1 text-sm border border-gray-300 rounded-md bg-white"
+            >
+              <option value={5}>5 Years</option>
+              <option value={7}>7 Years</option>
+              <option value={10}>10 Years</option>
+            </select>
+            <button
+              onClick={() => setCompareMode(!compareMode)}
+              className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                compareMode
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-white text-blue-600 border border-blue-300 hover:bg-blue-50'
+              }`}
+            >
+              {compareMode ? 'Exit Compare' : 'Compare All'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Summary KPI Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <KPICard
+          title={`${projectionYears}-Year Total FCF`}
+          value={formatFCFCurrency(fcfResult.totalFCF)}
+          icon={<span className="text-2xl">💰</span>}
+          subtitle={fcfResult.totalFCF >= 0 ? 'Cumulative cash generation' : 'Cumulative cash burn'}
+          trend={fcfResult.totalFCF >= 0 ? 'up' : 'down'}
+        />
+        <KPICard
+          title="Present Value"
+          value={formatFCFCurrency(fcfResult.totalPV)}
+          icon={<span className="text-2xl">📊</span>}
+          subtitle={`At ${(assumptions.corporate.discountRate * 100).toFixed(0)}% WACC`}
+        />
+        <KPICard
+          title="FCF Margin"
+          value={formatFCFPercent(fcfResult.avgFCFMargin)}
+          icon={<span className="text-2xl">📈</span>}
+          subtitle="Average over projection period"
+        />
+        <KPICard
+          title="Break-even Year"
+          value={fcfResult.breakEvenYear ? `Year ${fcfResult.breakEvenYear}` : 'N/A'}
+          icon={<span className="text-2xl">🎯</span>}
+          subtitle="First cumulative FCF positive"
+        />
+      </div>
+
+      {/* Scenario Selector */}
+      {!compareMode && (
+        <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-4">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-sm font-medium text-gray-700">Scenario:</span>
+            {scenarios.map((scenario) => (
+              <button
+                key={scenario.id}
+                onClick={() => selectScenario(scenario.id)}
+                className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                  scenario.id === selectedScenarioId
+                    ? 'text-white'
+                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                }`}
+                style={scenario.id === selectedScenarioId ? { backgroundColor: SCENARIO_COLORS[scenario.id] } : {}}
+              >
+                {scenario.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Main Content */}
+      {compareMode ? (
+        <ScenarioComparisonView allScenarios={allScenarios} selectedScenarioId={selectedScenarioId} />
+      ) : (
+        <>
+          {/* FCF Chart */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-lg font-semibold text-gray-900 mb-4">
+              Free Cash Flow Projection
+            </h3>
+            <div className="h-80">
+              <FCFProjectionChart data={fcfResult} scenarioColor={SCENARIO_COLORS[selectedScenarioId]} />
+            </div>
+          </div>
+
+          {/* Component Breakdown */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-lg font-semibold text-gray-900 mb-4">
+              FCF Component Breakdown
+            </h3>
+            <div className="h-80">
+              <FCFComponentChart data={componentBreakdown} />
+            </div>
+          </div>
+
+          {/* Detailed Table */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+            <div className="px-6 py-4 border-b border-gray-100">
+              <h3 className="text-lg font-semibold text-gray-900">
+                FCF Projection Detail
+              </h3>
+              <p className="text-sm text-gray-500 mt-1">
+                Year-by-year breakdown of FCF components
+              </p>
+            </div>
+            <FCFDetailTable data={fcfResult} />
+          </div>
+        </>
+      )}
+
+      {/* Summary Totals */}
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">
+          {projectionYears}-Year Summary
+        </h3>
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+          <div className="text-center p-4 bg-blue-50 rounded-lg">
+            <p className="text-2xl font-bold text-blue-700">
+              {formatFCFCurrency(fcfResult.totalRevenue)}
+            </p>
+            <p className="text-sm text-blue-600">Total Revenue</p>
+          </div>
+          <div className="text-center p-4 bg-purple-50 rounded-lg">
+            <p className="text-2xl font-bold text-purple-700">
+              {formatFCFCurrency(fcfResult.totalEBITDA)}
+            </p>
+            <p className="text-sm text-purple-600">Total EBITDA</p>
+          </div>
+          <div className="text-center p-4 bg-orange-50 rounded-lg">
+            <p className="text-2xl font-bold text-orange-700">
+              ({formatFCFCurrency(fcfResult.totalCapex)})
+            </p>
+            <p className="text-sm text-orange-600">Total CapEx</p>
+          </div>
+          <div className="text-center p-4 bg-amber-50 rounded-lg">
+            <p className="text-2xl font-bold text-amber-700">
+              ({formatFCFCurrency(fcfResult.totalWCChange)})
+            </p>
+            <p className="text-sm text-amber-600">Total WC Change</p>
+          </div>
+          <div className={`text-center p-4 rounded-lg ${fcfResult.totalFCF >= 0 ? 'bg-green-50' : 'bg-red-50'}`}>
+            <p className={`text-2xl font-bold ${fcfResult.totalFCF >= 0 ? 'text-green-700' : 'text-red-700'}`}>
+              {formatFCFCurrency(fcfResult.totalFCF)}
+            </p>
+            <p className={`text-sm ${fcfResult.totalFCF >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+              Total FCF
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// FCF Projection Line/Bar Chart
+function FCFProjectionChart({ data, scenarioColor }: { data: FCFProjectionResult; scenarioColor: string }) {
+  const chartData = data.years.map((y) => ({
+    year: `Y${y.year}`,
+    fcf: y.fcf,
+    pv: y.presentValue,
+    cumulativeFCF: y.cumulativeFCF,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <ComposedChart data={chartData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+        <XAxis dataKey="year" tick={{ fill: '#6b7280', fontSize: 12 }} />
+        <YAxis
+          yAxisId="left"
+          tick={{ fill: '#6b7280', fontSize: 11 }}
+          tickFormatter={(v) => formatFCFCurrency(v)}
+        />
+        <YAxis
+          yAxisId="right"
+          orientation="right"
+          tick={{ fill: '#6b7280', fontSize: 11 }}
+          tickFormatter={(v) => formatFCFCurrency(v)}
+        />
+        <Tooltip
+          formatter={(value: number, name: string) => [
+            formatFCFCurrency(value, false),
+            name === 'fcf' ? 'FCF' : name === 'pv' ? 'Present Value' : 'Cumulative FCF',
+          ]}
+          contentStyle={{ backgroundColor: '#fff', border: '1px solid #e5e7eb', borderRadius: '8px' }}
+        />
+        <Legend />
+        <ReferenceLine yAxisId="left" y={0} stroke="#9ca3af" strokeDasharray="3 3" />
+        <Bar yAxisId="left" dataKey="fcf" name="FCF" radius={[4, 4, 0, 0]}>
+          {chartData.map((entry, index) => (
+            <Cell key={`cell-${index}`} fill={entry.fcf >= 0 ? scenarioColor : '#ef4444'} fillOpacity={0.8} />
+          ))}
+        </Bar>
+        <Line
+          yAxisId="right"
+          type="monotone"
+          dataKey="cumulativeFCF"
+          name="Cumulative FCF"
+          stroke="#8b5cf6"
+          strokeWidth={2}
+          dot={{ fill: '#8b5cf6', r: 4 }}
+        />
+      </ComposedChart>
+    </ResponsiveContainer>
+  );
+}
+
+// FCF Component Waterfall Chart
+function FCFComponentChart({ data }: { data: ReturnType<typeof getFCFComponentBreakdown> }) {
+  // Prepare data for stacked bar chart showing components
+  const chartData = data.map((d) => ({
+    year: `Y${d.year}`,
+    EBITDA: d.ebitda,
+    Taxes: d.taxes,
+    CapEx: d.capex,
+    'WC Change': d.wcChange,
+    FCF: d.fcf,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={chartData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+        <XAxis dataKey="year" tick={{ fill: '#6b7280', fontSize: 12 }} />
+        <YAxis tick={{ fill: '#6b7280', fontSize: 11 }} tickFormatter={(v) => formatFCFCurrency(v)} />
+        <Tooltip
+          formatter={(value: number, name: string) => [formatFCFCurrency(value, false), name]}
+          contentStyle={{ backgroundColor: '#fff', border: '1px solid #e5e7eb', borderRadius: '8px' }}
+        />
+        <Legend />
+        <ReferenceLine y={0} stroke="#9ca3af" strokeDasharray="3 3" />
+        <Bar dataKey="EBITDA" stackId="a" fill="#3b82f6" />
+        <Bar dataKey="Taxes" stackId="a" fill="#ef4444" />
+        <Bar dataKey="CapEx" stackId="a" fill="#f97316" />
+        <Bar dataKey="WC Change" stackId="a" fill="#eab308" />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+// FCF Detail Table
+function FCFDetailTable({ data }: { data: FCFProjectionResult }) {
+  const rows = [
+    { label: 'Units', values: data.years.map((y) => y.units.toLocaleString()), className: 'font-medium' },
+    { label: 'Revenue', values: data.years.map((y) => formatFCFCurrency(y.revenue, false)), className: 'text-blue-700' },
+    { label: 'divider', values: [] },
+    { label: 'EBITDA', values: data.years.map((y) => formatFCFCurrency(y.ebitda, false)), className: 'font-medium' },
+    { label: 'EBITDA Margin', values: data.years.map((y) => formatFCFPercent(y.ebitdaMarginPct)), className: 'text-gray-500 text-sm' },
+    { label: 'divider', values: [] },
+    { label: 'Less: Taxes', values: data.years.map((y) => `(${formatFCFCurrency(y.taxes, false)})`), className: 'text-red-600' },
+    { label: 'Less: CapEx', values: data.years.map((y) => `(${formatFCFCurrency(y.capex, false)})`), className: 'text-red-600' },
+    { label: 'Less: ΔWC', values: data.years.map((y) => y.workingCapitalChange >= 0 ? `(${formatFCFCurrency(y.workingCapitalChange, false)})` : formatFCFCurrency(Math.abs(y.workingCapitalChange), false)), className: 'text-red-600' },
+    { label: 'divider', values: [] },
+    { label: 'Free Cash Flow', values: data.years.map((y) => formatFCFCurrency(y.fcf, false)), className: 'font-bold', highlight: true },
+    { label: 'FCF Margin', values: data.years.map((y) => formatFCFPercent(y.fcfMarginPct)), className: 'text-gray-500 text-sm' },
+    { label: 'divider', values: [] },
+    { label: 'Discount Factor', values: data.years.map((y) => y.discountFactor.toFixed(4)), className: 'text-gray-500 text-sm' },
+    { label: 'Present Value', values: data.years.map((y) => formatFCFCurrency(y.presentValue, false)), className: 'font-medium text-purple-700' },
+    { label: 'divider', values: [] },
+    { label: 'Cumulative FCF', values: data.years.map((y) => formatFCFCurrency(y.cumulativeFCF, false)), className: 'font-medium text-blue-700' },
+    { label: 'Cumulative PV', values: data.years.map((y) => formatFCFCurrency(y.cumulativePV, false)), className: 'font-medium text-purple-700' },
+  ];
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full">
+        <thead>
+          <tr className="bg-gray-50">
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Metric
+            </th>
+            {data.years.map((y) => (
+              <th key={y.year} className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Year {y.year}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {rows.map((row, idx) => {
+            if (row.label === 'divider') {
+              return (
+                <tr key={idx} className="bg-gray-50">
+                  <td colSpan={data.years.length + 1} className="h-2"></td>
+                </tr>
+              );
+            }
+            return (
+              <tr key={row.label} className={(row as { highlight?: boolean }).highlight ? 'bg-green-50' : 'hover:bg-gray-50'}>
+                <td className="px-6 py-3 text-sm text-gray-900">{row.label}</td>
+                {row.values.map((value, i) => (
+                  <td key={i} className={`px-4 py-3 text-sm text-right ${row.className || ''}`}>
+                    {value}
+                  </td>
+                ))}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// Scenario Comparison View
+function ScenarioComparisonView({
+  allScenarios,
+  selectedScenarioId,
+}: {
+  allScenarios: FCFScenarioComparison;
+  selectedScenarioId: string;
+}) {
+  const chartData = allScenarios.scenarioOrder.map((s) => ({
+    scenario: allScenarios.scenarios[s].scenarioLabel,
+    scenarioId: s,
+    totalFCF: allScenarios.scenarios[s].totalFCF,
+    totalPV: allScenarios.scenarios[s].totalPV,
+    avgMargin: allScenarios.scenarios[s].avgFCFMargin,
+  }));
+
+  // Year-by-year comparison data
+  const yearCount = allScenarios.scenarios['base'].years.length;
+  const yearComparisonData = Array.from({ length: yearCount }, (_, i) => {
+    const yearData: Record<string, number | string> = { year: `Y${i + 1}` };
+    for (const s of allScenarios.scenarioOrder) {
+      yearData[s] = allScenarios.scenarios[s].years[i].fcf;
+    }
+    return yearData;
+  });
+
+  return (
+    <div className="space-y-6">
+      {/* Summary Comparison */}
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">
+          Scenario Comparison Summary
+        </h3>
+        <div className="h-64">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={chartData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+              <XAxis dataKey="scenario" tick={{ fill: '#6b7280', fontSize: 12 }} />
+              <YAxis tick={{ fill: '#6b7280', fontSize: 11 }} tickFormatter={(v) => formatFCFCurrency(v)} />
+              <Tooltip
+                formatter={(value: number, name: string) => [
+                  formatFCFCurrency(value, false),
+                  name === 'totalFCF' ? 'Total FCF' : 'Present Value',
+                ]}
+                contentStyle={{ backgroundColor: '#fff', border: '1px solid #e5e7eb', borderRadius: '8px' }}
+              />
+              <Legend />
+              <Bar dataKey="totalFCF" name="Total FCF" radius={[4, 4, 0, 0]}>
+                {chartData.map((entry) => (
+                  <Cell
+                    key={entry.scenarioId}
+                    fill={SCENARIO_COLORS[entry.scenarioId]}
+                    fillOpacity={entry.scenarioId === selectedScenarioId ? 1 : 0.6}
+                    stroke={entry.scenarioId === selectedScenarioId ? '#000' : 'none'}
+                    strokeWidth={entry.scenarioId === selectedScenarioId ? 2 : 0}
+                  />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      {/* Year-by-Year Comparison */}
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">
+          Year-by-Year FCF Comparison
+        </h3>
+        <div className="h-80">
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart data={yearComparisonData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+              <XAxis dataKey="year" tick={{ fill: '#6b7280', fontSize: 12 }} />
+              <YAxis tick={{ fill: '#6b7280', fontSize: 11 }} tickFormatter={(v) => formatFCFCurrency(v)} />
+              <Tooltip
+                formatter={(value: number) => [formatFCFCurrency(value, false), '']}
+                contentStyle={{ backgroundColor: '#fff', border: '1px solid #e5e7eb', borderRadius: '8px' }}
+              />
+              <Legend />
+              <ReferenceLine y={0} stroke="#9ca3af" strokeDasharray="3 3" />
+              {allScenarios.scenarioOrder.map((s) => (
+                <Line
+                  key={s}
+                  type="monotone"
+                  dataKey={s}
+                  name={allScenarios.scenarios[s].scenarioLabel}
+                  stroke={SCENARIO_COLORS[s]}
+                  strokeWidth={s === selectedScenarioId ? 3 : 1.5}
+                  dot={{ fill: SCENARIO_COLORS[s], r: s === selectedScenarioId ? 5 : 3 }}
+                  strokeOpacity={s === selectedScenarioId ? 1 : 0.7}
+                />
+              ))}
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      {/* Comparison Table */}
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+        <div className="px-6 py-4 border-b border-gray-100">
+          <h3 className="text-lg font-semibold text-gray-900">
+            Scenario Metrics Comparison
+          </h3>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full">
+            <thead>
+              <tr className="bg-gray-50">
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Metric</th>
+                {allScenarios.scenarioOrder.map((s) => (
+                  <th
+                    key={s}
+                    className={`px-4 py-3 text-right text-xs font-medium uppercase ${
+                      s === selectedScenarioId ? 'bg-blue-100 text-blue-800' : 'text-gray-500'
+                    }`}
+                  >
+                    {allScenarios.scenarios[s].scenarioLabel}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              <tr className="hover:bg-gray-50">
+                <td className="px-6 py-3 text-sm text-gray-900">Total Revenue</td>
+                {allScenarios.scenarioOrder.map((s) => (
+                  <td key={s} className={`px-4 py-3 text-sm text-right ${s === selectedScenarioId ? 'bg-blue-50 font-medium' : ''}`}>
+                    {formatFCFCurrency(allScenarios.scenarios[s].totalRevenue)}
+                  </td>
+                ))}
+              </tr>
+              <tr className="hover:bg-gray-50">
+                <td className="px-6 py-3 text-sm text-gray-900">Total EBITDA</td>
+                {allScenarios.scenarioOrder.map((s) => (
+                  <td key={s} className={`px-4 py-3 text-sm text-right ${s === selectedScenarioId ? 'bg-blue-50 font-medium' : ''}`}>
+                    {formatFCFCurrency(allScenarios.scenarios[s].totalEBITDA)}
+                  </td>
+                ))}
+              </tr>
+              <tr className="hover:bg-gray-50">
+                <td className="px-6 py-3 text-sm text-gray-900">Total CapEx</td>
+                {allScenarios.scenarioOrder.map((s) => (
+                  <td key={s} className={`px-4 py-3 text-sm text-right ${s === selectedScenarioId ? 'bg-blue-50 font-medium' : ''}`}>
+                    ({formatFCFCurrency(allScenarios.scenarios[s].totalCapex)})
+                  </td>
+                ))}
+              </tr>
+              <tr className="hover:bg-gray-50">
+                <td className="px-6 py-3 text-sm text-gray-900">Total WC Change</td>
+                {allScenarios.scenarioOrder.map((s) => (
+                  <td key={s} className={`px-4 py-3 text-sm text-right ${s === selectedScenarioId ? 'bg-blue-50 font-medium' : ''}`}>
+                    ({formatFCFCurrency(allScenarios.scenarios[s].totalWCChange)})
+                  </td>
+                ))}
+              </tr>
+              <tr className="bg-green-50 font-bold">
+                <td className="px-6 py-3 text-sm text-gray-900">Total FCF</td>
+                {allScenarios.scenarioOrder.map((s) => (
+                  <td key={s} className={`px-4 py-3 text-sm text-right ${s === selectedScenarioId ? 'bg-blue-100' : ''}`}>
+                    {formatFCFCurrency(allScenarios.scenarios[s].totalFCF)}
+                  </td>
+                ))}
+              </tr>
+              <tr className="hover:bg-gray-50">
+                <td className="px-6 py-3 text-sm text-gray-900">Present Value</td>
+                {allScenarios.scenarioOrder.map((s) => (
+                  <td key={s} className={`px-4 py-3 text-sm text-right text-purple-700 ${s === selectedScenarioId ? 'bg-blue-50 font-medium' : ''}`}>
+                    {formatFCFCurrency(allScenarios.scenarios[s].totalPV)}
+                  </td>
+                ))}
+              </tr>
+              <tr className="hover:bg-gray-50">
+                <td className="px-6 py-3 text-sm text-gray-900">Avg FCF Margin</td>
+                {allScenarios.scenarioOrder.map((s) => (
+                  <td key={s} className={`px-4 py-3 text-sm text-right ${s === selectedScenarioId ? 'bg-blue-50 font-medium' : ''}`}>
+                    {formatFCFPercent(allScenarios.scenarios[s].avgFCFMargin)}
+                  </td>
+                ))}
+              </tr>
+              <tr className="hover:bg-gray-50">
+                <td className="px-6 py-3 text-sm text-gray-900">Break-even Year</td>
+                {allScenarios.scenarioOrder.map((s) => (
+                  <td key={s} className={`px-4 py-3 text-sm text-right ${s === selectedScenarioId ? 'bg-blue-50 font-medium' : ''}`}>
+                    {allScenarios.scenarios[s].breakEvenYear ? `Year ${allScenarios.scenarios[s].breakEvenYear}` : 'N/A'}
+                  </td>
+                ))}
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default FCFProjections;

--- a/src/valuation/index.ts
+++ b/src/valuation/index.ts
@@ -1,5 +1,6 @@
 export { Valuation } from './Valuation';
 export { ValuationSummary } from './ValuationSummary';
+export { FCFProjections } from './FCFProjections';
 export { SensitivityTable, IRRSensitivityTable } from './SensitivityTable';
 export { ScenarioComparison } from './ScenarioComparison';
 export { TerminalValueBreakdown } from './TerminalValueBreakdown';


### PR DESCRIPTION
## Summary
Implements the FCF projection engine as specified in Issue #21.

## Changes

### FCF Calculation Logic (`src/models/dcf/fcfProjections.ts`)
- **FCF Formula**: `FCF = EBIT(1-t) + D&A - CapEx - ΔWorkingCapital`
- Projects FCF by scenario (min/downside/base/upside/max)
- Supports 5, 7, or 10 year projections
- Calculates all P&L and FCF components per year
- Computes cumulative FCF and present values at WACC
- Identifies break-even year (first cumulative FCF positive)

### FCFProjections UI Component (`src/valuation/FCFProjections.tsx`)
- **KPI Cards**: Total FCF, Present Value, FCF Margin, Break-even Year
- **FCF Projection Chart**: Bar chart showing annual FCF with cumulative line
- **Component Breakdown Chart**: Stacked bar showing EBITDA → Taxes → CapEx → WC Change
- **Detailed Table**: Year-by-year breakdown of all metrics with margins
- **Scenario Comparison Mode**: Compare all scenarios side-by-side
- **Summary Totals**: Total Revenue, EBITDA, CapEx, WC Change, FCF

### Test Coverage (`src/models/dcf/__tests__/fcfProjections.test.ts`)
- 30 tests covering:
  - FCF formula verification
  - Cumulative calculations
  - Discount factor and PV calculations
  - Multi-scenario comparisons
  - Margin calculations (Gross, EBITDA, FCF)
  - Tax calculations (only on positive EBIT)

### Integration
- Uses existing adoption model for unit projections
- Uses assumptions store for all financial parameters
- New route at `/valuation/fcf`

## Acceptance Criteria
- [x] FCF calculation
- [x] Scenario comparison
- [x] Visualization

## Screenshots
_Add screenshots after review_

Closes #21