### PR TITLE
feat(capital): Raise scenario matrix with dilution & runway analysis

### DIFF
--- a/src/capital/RaiseScenarioMatrix.tsx
+++ b/src/capital/RaiseScenarioMatrix.tsx
@@ -1,0 +1,555 @@
+/**
+ * Raise Scenario Matrix Component
+ * 
+ * Interactive comparison matrix for capital raise scenarios.
+ * Shows dilution, runway, and valuation impact across raise amounts.
+ */
+
+import { useState, useMemo } from 'react';
+import {
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+  Legend,
+  ComposedChart,
+  Line,
+} from 'recharts';
+import {
+  buildRaiseScenarioMatrix,
+  formatRaiseCurrency,
+  formatRaisePercent,
+  DEFAULT_RAISE_AMOUNTS,
+  DEFAULT_PRE_MONEY_VALUATION,
+  type RaiseScenarioResult,
+  type RaiseScenarioMatrix as MatrixType,
+  type RaiseInstrument,
+} from '../models/raise';
+import { useAssumptionsStore } from '../stores/assumptionsStore';
+
+// Risk level colors
+const RISK_COLORS: Record<string, string> = {
+  critical: '#ef4444',   // red
+  low: '#f97316',        // orange
+  moderate: '#eab308',   // yellow
+  comfortable: '#22c55e', // green
+  extended: '#3b82f6',    // blue
+};
+
+const RISK_LABELS: Record<string, string> = {
+  critical: 'Critical (<6 mo)',
+  low: 'Low (6-12 mo)',
+  moderate: 'Moderate (12-18 mo)',
+  comfortable: 'Comfortable (18-24 mo)',
+  extended: 'Extended (24+ mo)',
+};
+
+interface InputFieldProps {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+  prefix?: string;
+  suffix?: string;
+  step?: number;
+  min?: number;
+  max?: number;
+}
+
+function InputField({ label, value, onChange, prefix, suffix, step = 1000, min = 0, max }: InputFieldProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-sm font-medium text-gray-600">{label}</label>
+      <div className="flex items-center">
+        {prefix && <span className="text-gray-500 mr-1">{prefix}</span>}
+        <input
+          type="number"
+          value={value}
+          onChange={(e) => onChange(Number(e.target.value))}
+          step={step}
+          min={min}
+          max={max}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-right"
+        />
+        {suffix && <span className="text-gray-500 ml-1">{suffix}</span>}
+      </div>
+    </div>
+  );
+}
+
+function InstrumentSelector({ 
+  value, 
+  onChange 
+}: { 
+  value: RaiseInstrument; 
+  onChange: (v: RaiseInstrument) => void;
+}) {
+  const instruments: { value: RaiseInstrument; label: string; desc: string }[] = [
+    { value: 'equity', label: 'Equity', desc: 'Priced round' },
+    { value: 'safe', label: 'SAFE', desc: 'Simple Agreement' },
+    { value: 'convertible_debt', label: 'Convertible', desc: 'Debt instrument' },
+  ];
+
+  return (
+    <div className="flex gap-2">
+      {instruments.map((inst) => (
+        <button
+          key={inst.value}
+          onClick={() => onChange(inst.value)}
+          className={`flex-1 px-4 py-2 rounded-lg border transition-colors ${
+            value === inst.value
+              ? 'bg-blue-600 text-white border-blue-600'
+              : 'bg-white text-gray-700 border-gray-300 hover:border-blue-400'
+          }`}
+        >
+          <div className="font-medium">{inst.label}</div>
+          <div className={`text-xs ${value === inst.value ? 'text-blue-100' : 'text-gray-500'}`}>
+            {inst.desc}
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ScenarioCard({ 
+  scenario, 
+  isRecommended 
+}: { 
+  scenario: RaiseScenarioResult; 
+  isRecommended: boolean;
+}) {
+  return (
+    <div
+      className={`rounded-xl border-2 p-4 transition-all ${
+        isRecommended
+          ? 'border-green-500 bg-green-50 shadow-lg'
+          : 'border-gray-200 bg-white hover:border-gray-300'
+      }`}
+    >
+      {isRecommended && (
+        <div className="flex items-center gap-1 text-green-600 text-xs font-semibold mb-2">
+          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+            <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+          </svg>
+          RECOMMENDED
+        </div>
+      )}
+      
+      <div className="text-2xl font-bold text-gray-900 mb-3">
+        {formatRaiseCurrency(scenario.raiseAmount)}
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex justify-between items-center">
+          <span className="text-sm text-gray-500">Dilution</span>
+          <span className="font-semibold text-gray-900">
+            {formatRaisePercent(scenario.dilutionPercent)}
+          </span>
+        </div>
+
+        <div className="flex justify-between items-center">
+          <span className="text-sm text-gray-500">Runway</span>
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-gray-900">
+              {scenario.runwayMonths === Infinity ? '∞' : `${scenario.runwayMonths} mo`}
+            </span>
+            <span
+              className="w-3 h-3 rounded-full"
+              style={{ backgroundColor: RISK_COLORS[scenario.runwayRiskLevel] }}
+              title={RISK_LABELS[scenario.runwayRiskLevel]}
+            />
+          </div>
+        </div>
+
+        <div className="flex justify-between items-center">
+          <span className="text-sm text-gray-500">Post-Money</span>
+          <span className="font-semibold text-gray-900">
+            {formatRaiseCurrency(scenario.postMoneyValuation)}
+          </span>
+        </div>
+
+        <div className="border-t border-gray-100 pt-3 mt-3">
+          <div className="flex justify-between items-center text-xs">
+            <span className="text-gray-500">Your Ownership</span>
+            <span className="font-medium text-gray-700">
+              {formatRaisePercent(scenario.founderOwnershipPost)}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MatrixTable({ matrix }: { matrix: MatrixType }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+              Raise Amount
+            </th>
+            <th className="px-4 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wider">
+              Dilution %
+            </th>
+            <th className="px-4 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wider">
+              Runway (mo)
+            </th>
+            <th className="px-4 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wider">
+              Post-Money
+            </th>
+            <th className="px-4 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wider">
+              Founder %
+            </th>
+            <th className="px-4 py-3 text-center text-xs font-semibold text-gray-600 uppercase tracking-wider">
+              Risk Level
+            </th>
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-gray-100">
+          {matrix.scenarios.map((s) => {
+            const isRecommended = s.raiseAmount === matrix.recommendedScenario?.raiseAmount;
+            return (
+              <tr
+                key={s.raiseAmount}
+                className={`${isRecommended ? 'bg-green-50' : ''} hover:bg-gray-50`}
+              >
+                <td className="px-4 py-4 whitespace-nowrap">
+                  <div className="flex items-center gap-2">
+                    {isRecommended && (
+                      <span className="flex h-2 w-2 rounded-full bg-green-500" />
+                    )}
+                    <span className="font-semibold text-gray-900">
+                      {formatRaiseCurrency(s.raiseAmount)}
+                    </span>
+                  </div>
+                </td>
+                <td className="px-4 py-4 whitespace-nowrap text-right text-sm">
+                  <span className={`font-medium ${s.dilutionPercent > 0.25 ? 'text-red-600' : 'text-gray-900'}`}>
+                    {formatRaisePercent(s.dilutionPercent)}
+                  </span>
+                </td>
+                <td className="px-4 py-4 whitespace-nowrap text-right text-sm font-medium text-gray-900">
+                  {s.runwayMonths === Infinity ? '∞' : s.runwayMonths}
+                </td>
+                <td className="px-4 py-4 whitespace-nowrap text-right text-sm font-medium text-gray-900">
+                  {formatRaiseCurrency(s.postMoneyValuation)}
+                </td>
+                <td className="px-4 py-4 whitespace-nowrap text-right text-sm font-medium text-gray-900">
+                  {formatRaisePercent(s.founderOwnershipPost)}
+                </td>
+                <td className="px-4 py-4 whitespace-nowrap text-center">
+                  <span
+                    className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium"
+                    style={{
+                      backgroundColor: `${RISK_COLORS[s.runwayRiskLevel]}20`,
+                      color: RISK_COLORS[s.runwayRiskLevel],
+                    }}
+                  >
+                    {s.runwayRiskLevel}
+                  </span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function DilutionRunwayChart({ matrix }: { matrix: MatrixType }) {
+  const data = matrix.scenarios.map((s) => ({
+    name: formatRaiseCurrency(s.raiseAmount),
+    dilution: s.dilutionPercent * 100,
+    runway: Math.min(s.runwayMonths, 36), // Cap at 36 for chart
+    runwayRisk: s.runwayRiskLevel,
+    isRecommended: s.raiseAmount === matrix.recommendedScenario?.raiseAmount,
+  }));
+
+  return (
+    <div className="h-80">
+      <ResponsiveContainer width="100%" height="100%">
+        <ComposedChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+          <XAxis dataKey="name" tick={{ fill: '#6b7280', fontSize: 12 }} />
+          <YAxis
+            yAxisId="left"
+            tick={{ fill: '#6b7280', fontSize: 12 }}
+            label={{ value: 'Dilution %', angle: -90, position: 'insideLeft', fill: '#6b7280' }}
+          />
+          <YAxis
+            yAxisId="right"
+            orientation="right"
+            tick={{ fill: '#6b7280', fontSize: 12 }}
+            label={{ value: 'Runway (months)', angle: 90, position: 'insideRight', fill: '#6b7280' }}
+          />
+          <Tooltip
+            formatter={(value: number, name: string) => {
+              if (name === 'dilution') return [`${value.toFixed(1)}%`, 'Dilution'];
+              return [`${value} months`, 'Runway'];
+            }}
+            contentStyle={{
+              backgroundColor: 'white',
+              border: '1px solid #e5e7eb',
+              borderRadius: '8px',
+            }}
+          />
+          <Legend />
+          <Bar
+            yAxisId="left"
+            dataKey="dilution"
+            name="Dilution %"
+            radius={[4, 4, 0, 0]}
+          >
+            {data.map((entry, index) => (
+              <Cell
+                key={`cell-${index}`}
+                fill={entry.isRecommended ? '#22c55e' : '#3b82f6'}
+                opacity={entry.isRecommended ? 1 : 0.7}
+              />
+            ))}
+          </Bar>
+          <Line
+            yAxisId="right"
+            type="monotone"
+            dataKey="runway"
+            name="Runway (months)"
+            stroke="#f59e0b"
+            strokeWidth={3}
+            dot={{ r: 6, fill: '#f59e0b' }}
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+export function RaiseScenarioMatrix() {
+  // Get assumptions from store for defaults
+  const assumptions = useAssumptionsStore();
+  
+  // Local state for inputs
+  const [preMoneyValuation, setPreMoneyValuation] = useState(DEFAULT_PRE_MONEY_VALUATION);
+  const [currentCash, setCurrentCash] = useState(assumptions.capital.initialInvestment);
+  const [instrument, setInstrument] = useState<RaiseInstrument>('equity');
+  const [monthlyBurn, setMonthlyBurn] = useState(35_000);
+  const [viewMode, setViewMode] = useState<'cards' | 'table'>('cards');
+
+  // Calculate burn rate components
+  const burnRate = useMemo(() => {
+    return {
+      payroll: monthlyBurn * 0.6,
+      marketing: monthlyBurn * 0.2,
+      operations: monthlyBurn * 0.2,
+      cogs: 0,
+      total: monthlyBurn,
+    };
+  }, [monthlyBurn]);
+
+  // Build the scenario matrix
+  const matrix = useMemo(() => {
+    return buildRaiseScenarioMatrix(
+      burnRate,
+      currentCash,
+      preMoneyValuation,
+      DEFAULT_RAISE_AMOUNTS,
+      instrument
+    );
+  }, [burnRate, currentCash, preMoneyValuation, instrument]);
+
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900">Raise Scenario Analysis</h2>
+        <p className="text-gray-500 mt-1">
+          Compare dilution, runway, and valuation impact across different raise amounts
+        </p>
+      </div>
+
+      {/* Inputs Panel */}
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Assumptions</h3>
+        
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
+          <InputField
+            label="Pre-Money Valuation"
+            value={preMoneyValuation}
+            onChange={setPreMoneyValuation}
+            prefix="$"
+            step={100000}
+            min={500000}
+          />
+          <InputField
+            label="Current Cash"
+            value={currentCash}
+            onChange={setCurrentCash}
+            prefix="$"
+            step={10000}
+            min={0}
+          />
+          <InputField
+            label="Monthly Burn Rate"
+            value={monthlyBurn}
+            onChange={setMonthlyBurn}
+            prefix="$"
+            step={5000}
+            min={1000}
+          />
+          <div className="flex flex-col gap-1">
+            <label className="text-sm font-medium text-gray-600">Current Runway</label>
+            <div className="flex items-center h-[42px] px-3 bg-gray-50 rounded-lg">
+              <span className="text-lg font-semibold text-gray-900">
+                {Math.floor(currentCash / monthlyBurn)} months
+              </span>
+              <span
+                className="ml-2 w-3 h-3 rounded-full"
+                style={{
+                  backgroundColor: RISK_COLORS[
+                    Math.floor(currentCash / monthlyBurn) < 6 ? 'critical' :
+                    Math.floor(currentCash / monthlyBurn) < 12 ? 'low' :
+                    Math.floor(currentCash / monthlyBurn) < 18 ? 'moderate' :
+                    Math.floor(currentCash / monthlyBurn) < 24 ? 'comfortable' : 'extended'
+                  ],
+                }}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="border-t border-gray-100 pt-4">
+          <label className="text-sm font-medium text-gray-600 block mb-2">Instrument Type</label>
+          <InstrumentSelector value={instrument} onChange={setInstrument} />
+        </div>
+      </div>
+
+      {/* Recommendation Banner */}
+      {matrix.recommendedScenario && (
+        <div className="bg-gradient-to-r from-green-50 to-emerald-50 border border-green-200 rounded-xl p-4">
+          <div className="flex items-start gap-3">
+            <div className="flex-shrink-0">
+              <svg className="w-6 h-6 text-green-600" fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+              </svg>
+            </div>
+            <div>
+              <h4 className="font-semibold text-green-800">Optimal Raise Recommendation</h4>
+              <p className="text-green-700 text-sm mt-1">{matrix.recommendationReason}</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* View Toggle */}
+      <div className="flex justify-end">
+        <div className="inline-flex rounded-lg border border-gray-200 bg-white p-1">
+          <button
+            onClick={() => setViewMode('cards')}
+            className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+              viewMode === 'cards'
+                ? 'bg-gray-100 text-gray-900'
+                : 'text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            Cards
+          </button>
+          <button
+            onClick={() => setViewMode('table')}
+            className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+              viewMode === 'table'
+                ? 'bg-gray-100 text-gray-900'
+                : 'text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            Table
+          </button>
+        </div>
+      </div>
+
+      {/* Scenario Cards or Table */}
+      {viewMode === 'cards' ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          {matrix.scenarios.map((scenario) => (
+            <ScenarioCard
+              key={scenario.raiseAmount}
+              scenario={scenario}
+              isRecommended={scenario.raiseAmount === matrix.recommendedScenario?.raiseAmount}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="bg-white rounded-xl shadow-sm border border-gray-100">
+          <MatrixTable matrix={matrix} />
+        </div>
+      )}
+
+      {/* Chart */}
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">
+          Dilution vs Runway Trade-off
+        </h3>
+        <DilutionRunwayChart matrix={matrix} />
+      </div>
+
+      {/* Burn Rate Breakdown */}
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">
+          Monthly Burn Breakdown
+        </h3>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div className="text-center p-4 bg-gray-50 rounded-lg">
+            <div className="text-sm text-gray-500 mb-1">Payroll</div>
+            <div className="text-xl font-semibold text-gray-900">
+              {formatRaiseCurrency(burnRate.payroll)}
+            </div>
+            <div className="text-xs text-gray-400">60%</div>
+          </div>
+          <div className="text-center p-4 bg-gray-50 rounded-lg">
+            <div className="text-sm text-gray-500 mb-1">Marketing</div>
+            <div className="text-xl font-semibold text-gray-900">
+              {formatRaiseCurrency(burnRate.marketing)}
+            </div>
+            <div className="text-xs text-gray-400">20%</div>
+          </div>
+          <div className="text-center p-4 bg-gray-50 rounded-lg">
+            <div className="text-sm text-gray-500 mb-1">Operations</div>
+            <div className="text-xl font-semibold text-gray-900">
+              {formatRaiseCurrency(burnRate.operations)}
+            </div>
+            <div className="text-xs text-gray-400">20%</div>
+          </div>
+          <div className="text-center p-4 bg-blue-50 rounded-lg">
+            <div className="text-sm text-blue-600 mb-1">Total Burn</div>
+            <div className="text-xl font-semibold text-blue-700">
+              {formatRaiseCurrency(burnRate.total)}
+            </div>
+            <div className="text-xs text-blue-400">/month</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Risk Legend */}
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Runway Risk Levels</h3>
+        <div className="flex flex-wrap gap-4">
+          {Object.entries(RISK_LABELS).map(([key, label]) => (
+            <div key={key} className="flex items-center gap-2">
+              <span
+                className="w-4 h-4 rounded-full"
+                style={{ backgroundColor: RISK_COLORS[key] }}
+              />
+              <span className="text-sm text-gray-600">{label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default RaiseScenarioMatrix;

--- a/src/capital/index.ts
+++ b/src/capital/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Capital Module
+ * 
+ * Capital raise scenario analysis and funding planning tools.
+ */
+
+export { RaiseScenarioMatrix } from './RaiseScenarioMatrix';

--- a/src/models/raise/__tests__/raise.test.ts
+++ b/src/models/raise/__tests__/raise.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Tests for Raise Scenario Calculator
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  calculateDilution,
+  calculateRunway,
+  assessRunwayRisk,
+  calculateBurnRate,
+  calculateRaiseScenario,
+  buildRaiseScenarioMatrix,
+} from '../calculator';
+import type { BurnRateComponents, RaiseScenarioInput } from '../types';
+
+describe('calculateDilution', () => {
+  it('calculates dilution correctly for equity raise', () => {
+    const result = calculateDilution(500_000, 2_000_000);
+    
+    expect(result.postMoneyValuation).toBe(2_500_000);
+    expect(result.dilutionPercent).toBe(0.20); // 500k / 2.5M = 20%
+  });
+
+  it('handles small raises', () => {
+    const result = calculateDilution(100_000, 2_000_000);
+    
+    expect(result.postMoneyValuation).toBe(2_100_000);
+    expect(result.dilutionPercent).toBeCloseTo(0.0476, 4); // ~4.76%
+  });
+
+  it('handles large raises', () => {
+    const result = calculateDilution(1_000_000, 2_000_000);
+    
+    expect(result.postMoneyValuation).toBe(3_000_000);
+    expect(result.dilutionPercent).toBeCloseTo(0.333, 3); // ~33.3%
+  });
+
+  it('throws for negative pre-money valuation', () => {
+    expect(() => calculateDilution(500_000, -1_000_000)).toThrow();
+  });
+
+  it('throws for negative raise amount', () => {
+    expect(() => calculateDilution(-500_000, 2_000_000)).toThrow();
+  });
+});
+
+describe('calculateRunway', () => {
+  it('calculates runway correctly', () => {
+    const runway = calculateRunway(600_000, 50_000);
+    expect(runway).toBe(12); // 600k / 50k = 12 months
+  });
+
+  it('returns Infinity for zero burn', () => {
+    const runway = calculateRunway(100_000, 0);
+    expect(runway).toBe(Infinity);
+  });
+
+  it('handles fractional months (floors)', () => {
+    const runway = calculateRunway(550_000, 50_000);
+    expect(runway).toBe(11); // 11.0 months floored
+  });
+});
+
+describe('assessRunwayRisk', () => {
+  it('returns critical for < 6 months', () => {
+    expect(assessRunwayRisk(3)).toBe('critical');
+    expect(assessRunwayRisk(5)).toBe('critical');
+  });
+
+  it('returns low for 6-11 months', () => {
+    expect(assessRunwayRisk(6)).toBe('low');
+    expect(assessRunwayRisk(11)).toBe('low');
+  });
+
+  it('returns moderate for 12-17 months', () => {
+    expect(assessRunwayRisk(12)).toBe('moderate');
+    expect(assessRunwayRisk(17)).toBe('moderate');
+  });
+
+  it('returns comfortable for 18-23 months', () => {
+    expect(assessRunwayRisk(18)).toBe('comfortable');
+    expect(assessRunwayRisk(23)).toBe('comfortable');
+  });
+
+  it('returns extended for 24+ months', () => {
+    expect(assessRunwayRisk(24)).toBe('extended');
+    expect(assessRunwayRisk(36)).toBe('extended');
+  });
+});
+
+describe('calculateBurnRate', () => {
+  it('calculates total burn correctly', () => {
+    const burn = calculateBurnRate(
+      3,        // headcount
+      80_000,   // avg salary
+      1.3,      // benefits multiplier
+      5_000,    // monthly marketing
+      3_000,    // monthly operations
+      0         // COGS
+    );
+
+    // Payroll: (3 * 80k * 1.3) / 12 = 26,000/month
+    expect(burn.payroll).toBe(26_000);
+    expect(burn.marketing).toBe(5_000);
+    expect(burn.operations).toBe(3_000);
+    expect(burn.total).toBe(34_000);
+  });
+
+  it('includes COGS in total burn', () => {
+    const burn = calculateBurnRate(2, 60_000, 1.25, 2_000, 1_000, 5_000);
+    
+    expect(burn.cogs).toBe(5_000);
+    expect(burn.total).toBe(burn.payroll + 2_000 + 1_000 + 5_000);
+  });
+});
+
+describe('calculateRaiseScenario', () => {
+  const baseBurnRate: BurnRateComponents = {
+    payroll: 25_000,
+    marketing: 5_000,
+    operations: 3_000,
+    cogs: 0,
+    total: 33_000,
+  };
+
+  it('calculates full scenario correctly', () => {
+    const input: RaiseScenarioInput = {
+      raiseAmount: 500_000,
+      instrument: 'equity',
+      preMoneyValuation: 2_000_000,
+    };
+
+    const result = calculateRaiseScenario(input, baseBurnRate, 50_000);
+
+    expect(result.raiseAmount).toBe(500_000);
+    expect(result.postMoneyValuation).toBe(2_500_000);
+    expect(result.dilutionPercent).toBe(0.20);
+    expect(result.runwayMonths).toBe(16); // (50k + 500k) / 33k = 16.67 floored
+    expect(result.founderOwnershipPost).toBe(0.80); // 1.0 * (1 - 0.20)
+    expect(result.investorOwnershipPost).toBe(0.20);
+  });
+
+  it('calculates per-dollar metrics', () => {
+    const input: RaiseScenarioInput = {
+      raiseAmount: 250_000,
+      instrument: 'equity',
+      preMoneyValuation: 2_000_000,
+    };
+
+    const result = calculateRaiseScenario(input, baseBurnRate, 50_000);
+    
+    // Dilution per $100k: (dilution / amount) * 100k
+    const expectedDilutionPerDollar = (result.dilutionPercent / 250_000) * 100_000;
+    expect(result.dilutionPerDollar).toBeCloseTo(expectedDilutionPerDollar, 6);
+  });
+
+  it('adjusts for SAFE discount', () => {
+    const input: RaiseScenarioInput = {
+      raiseAmount: 250_000,
+      instrument: 'safe',
+      preMoneyValuation: 2_000_000,
+      safeTerms: {
+        valuationCap: 2_000_000,
+        discountRate: 0.20, // 20% discount
+        mfnClause: true,
+        proRataRights: true,
+      },
+    };
+
+    const result = calculateRaiseScenario(input, baseBurnRate, 50_000);
+    
+    // Dilution should be higher due to discount
+    const baseDilution = 250_000 / (2_000_000 + 250_000);
+    expect(result.dilutionPercent).toBeGreaterThan(baseDilution);
+  });
+});
+
+describe('buildRaiseScenarioMatrix', () => {
+  const burnRate: BurnRateComponents = {
+    payroll: 20_000,
+    marketing: 5_000,
+    operations: 5_000,
+    cogs: 0,
+    total: 30_000,
+  };
+
+  it('builds matrix with all default raise amounts', () => {
+    const matrix = buildRaiseScenarioMatrix(burnRate, 50_000, 2_000_000);
+
+    expect(matrix.scenarios).toHaveLength(4); // $100k, $250k, $500k, $1M
+    expect(matrix.burnRate).toBe(burnRate);
+    expect(matrix.currentCash).toBe(50_000);
+  });
+
+  it('scenarios are sorted by raise amount', () => {
+    const matrix = buildRaiseScenarioMatrix(burnRate, 50_000);
+
+    const amounts = matrix.scenarios.map(s => s.raiseAmount);
+    expect(amounts).toEqual([100_000, 250_000, 500_000, 1_000_000]);
+  });
+
+  it('provides a recommended scenario', () => {
+    const matrix = buildRaiseScenarioMatrix(burnRate, 50_000);
+
+    expect(matrix.recommendedScenario).not.toBeNull();
+    expect(matrix.recommendationReason).toContain('Recommended');
+  });
+
+  it('allows custom raise amounts', () => {
+    const customAmounts = [150_000, 300_000, 750_000];
+    const matrix = buildRaiseScenarioMatrix(
+      burnRate,
+      50_000,
+      2_000_000,
+      customAmounts
+    );
+
+    expect(matrix.scenarios).toHaveLength(3);
+    expect(matrix.scenarios.map(s => s.raiseAmount)).toEqual(customAmounts);
+  });
+
+  it('handles different instruments', () => {
+    const matrix = buildRaiseScenarioMatrix(
+      burnRate,
+      50_000,
+      2_000_000,
+      [250_000],
+      'safe'
+    );
+
+    expect(matrix.scenarios[0].instrument).toBe('safe');
+  });
+
+  it('respects founder current ownership', () => {
+    // Founder already diluted to 80%
+    const matrix = buildRaiseScenarioMatrix(
+      burnRate,
+      50_000,
+      2_000_000,
+      [500_000],
+      'equity',
+      0.80
+    );
+
+    // After 20% dilution, should be 80% * 80% = 64%
+    expect(matrix.scenarios[0].founderOwnershipPost).toBeCloseTo(0.64, 2);
+  });
+});
+
+describe('runway risk assessment in scenarios', () => {
+  const burnRate: BurnRateComponents = {
+    payroll: 40_000,
+    marketing: 5_000,
+    operations: 5_000,
+    cogs: 0,
+    total: 50_000,
+  };
+
+  it('identifies critical runway with small raise', () => {
+    const matrix = buildRaiseScenarioMatrix(
+      burnRate,
+      0, // No existing cash
+      2_000_000,
+      [100_000] // Only 2 months runway
+    );
+
+    expect(matrix.scenarios[0].runwayRiskLevel).toBe('critical');
+  });
+
+  it('identifies extended runway with large raise', () => {
+    const matrix = buildRaiseScenarioMatrix(
+      burnRate,
+      100_000, // Some existing cash
+      2_000_000,
+      [1_500_000] // 32 months runway
+    );
+
+    expect(matrix.scenarios[0].runwayRiskLevel).toBe('extended');
+  });
+});

--- a/src/models/raise/calculator.ts
+++ b/src/models/raise/calculator.ts
@@ -1,0 +1,289 @@
+/**
+ * Raise Scenario Calculator
+ * 
+ * Functions for calculating capital raise scenarios, dilution,
+ * runway projections, and optimal raise recommendations.
+ */
+
+import type {
+  RaiseScenarioInput,
+  RaiseScenarioResult,
+  RaiseScenarioMatrix,
+  BurnRateComponents,
+} from './types';
+import {
+  DEFAULT_RAISE_AMOUNTS,
+  DEFAULT_PRE_MONEY_VALUATION,
+  FOUNDER_STARTING_OWNERSHIP,
+} from './types';
+
+/**
+ * Calculate dilution percentage for an equity raise
+ * 
+ * Dilution = Raise Amount / Post-Money Valuation
+ * Post-Money = Pre-Money + Raise Amount
+ */
+export function calculateDilution(
+  raiseAmount: number,
+  preMoneyValuation: number
+): { dilutionPercent: number; postMoneyValuation: number } {
+  if (preMoneyValuation <= 0) {
+    throw new Error('Pre-money valuation must be positive');
+  }
+  if (raiseAmount < 0) {
+    throw new Error('Raise amount cannot be negative');
+  }
+  
+  const postMoneyValuation = preMoneyValuation + raiseAmount;
+  const dilutionPercent = raiseAmount / postMoneyValuation;
+  
+  return { dilutionPercent, postMoneyValuation };
+}
+
+/**
+ * Calculate runway in months given cash and burn rate
+ */
+export function calculateRunway(
+  totalCash: number,
+  monthlyBurn: number
+): number {
+  if (monthlyBurn <= 0) {
+    // If no burn (profitable or no expenses), infinite runway
+    return Infinity;
+  }
+  
+  return Math.floor(totalCash / monthlyBurn);
+}
+
+/**
+ * Assess runway risk level based on months of runway
+ */
+export function assessRunwayRisk(
+  runwayMonths: number
+): 'critical' | 'low' | 'moderate' | 'comfortable' | 'extended' {
+  if (runwayMonths < 6) return 'critical';
+  if (runwayMonths < 12) return 'low';
+  if (runwayMonths < 18) return 'moderate';
+  if (runwayMonths < 24) return 'comfortable';
+  return 'extended';
+}
+
+/**
+ * Calculate burn rate from component assumptions
+ */
+export function calculateBurnRate(
+  headcount: number,
+  avgSalary: number,
+  benefitsMultiplier: number,
+  monthlyMarketing: number,
+  monthlyOperations: number,
+  monthlyCOGS: number = 0
+): BurnRateComponents {
+  const payroll = (headcount * avgSalary * benefitsMultiplier) / 12;
+  
+  return {
+    payroll,
+    marketing: monthlyMarketing,
+    operations: monthlyOperations,
+    cogs: monthlyCOGS,
+    total: payroll + monthlyMarketing + monthlyOperations + monthlyCOGS,
+  };
+}
+
+/**
+ * Calculate a single raise scenario result
+ */
+export function calculateRaiseScenario(
+  input: RaiseScenarioInput,
+  burnRate: BurnRateComponents,
+  currentCash: number,
+  founderCurrentOwnership: number = FOUNDER_STARTING_OWNERSHIP
+): RaiseScenarioResult {
+  const { raiseAmount, instrument, preMoneyValuation } = input;
+  
+  // Calculate dilution and post-money
+  const { dilutionPercent, postMoneyValuation } = calculateDilution(
+    raiseAmount,
+    preMoneyValuation
+  );
+  
+  // Adjust for SAFE/Convertible (may have additional dilution)
+  let effectiveDilution = dilutionPercent;
+  if (instrument === 'safe' && input.safeTerms?.discountRate) {
+    // SAFE discount means more shares at conversion
+    effectiveDilution = dilutionPercent * (1 + input.safeTerms.discountRate * 0.5);
+  }
+  if (instrument === 'convertible_debt' && input.convertibleTerms?.discountRate) {
+    effectiveDilution = dilutionPercent * (1 + input.convertibleTerms.discountRate * 0.5);
+  }
+  
+  // Calculate runway with new cash
+  const totalCashAfterRaise = currentCash + raiseAmount;
+  const runwayMonths = calculateRunway(totalCashAfterRaise, burnRate.total);
+  
+  // Ownership calculations
+  const founderOwnershipPost = founderCurrentOwnership * (1 - effectiveDilution);
+  const investorOwnershipPost = effectiveDilution;
+  
+  // Per-dollar metrics (per $100k)
+  const dilutionPerDollar = (effectiveDilution / raiseAmount) * 100_000;
+  const monthsPerDollar = (runwayMonths / raiseAmount) * 100_000;
+  
+  return {
+    raiseAmount,
+    instrument,
+    preMoneyValuation,
+    postMoneyValuation,
+    dilutionPercent: effectiveDilution,
+    runwayMonths,
+    founderOwnershipPost,
+    investorOwnershipPost,
+    dilutionPerDollar,
+    monthsPerDollar,
+    runwayRiskLevel: assessRunwayRisk(runwayMonths),
+  };
+}
+
+/**
+ * Score a scenario for recommendation
+ * Higher score = better scenario
+ */
+function scoreScenario(scenario: RaiseScenarioResult): number {
+  let score = 0;
+  
+  // Runway scoring (prefer 18-24 months)
+  if (scenario.runwayMonths >= 18 && scenario.runwayMonths <= 24) {
+    score += 50; // Optimal range
+  } else if (scenario.runwayMonths >= 12 && scenario.runwayMonths < 18) {
+    score += 30;
+  } else if (scenario.runwayMonths > 24) {
+    score += 25; // Over-capitalized penalty
+  } else if (scenario.runwayMonths >= 6) {
+    score += 10;
+  }
+  
+  // Dilution scoring (lower is better)
+  if (scenario.dilutionPercent <= 0.10) {
+    score += 40;
+  } else if (scenario.dilutionPercent <= 0.15) {
+    score += 30;
+  } else if (scenario.dilutionPercent <= 0.20) {
+    score += 20;
+  } else if (scenario.dilutionPercent <= 0.25) {
+    score += 10;
+  }
+  
+  // Founder ownership protection
+  if (scenario.founderOwnershipPost >= 0.80) {
+    score += 15;
+  } else if (scenario.founderOwnershipPost >= 0.70) {
+    score += 10;
+  }
+  
+  return score;
+}
+
+/**
+ * Generate recommendation reason based on scenario
+ */
+function generateRecommendation(
+  scenario: RaiseScenarioResult
+): string {
+  const reasons: string[] = [];
+  
+  // Runway analysis
+  if (scenario.runwayMonths >= 18 && scenario.runwayMonths <= 24) {
+    reasons.push('provides optimal 18-24 month runway');
+  } else if (scenario.runwayMonths > 24) {
+    reasons.push(`provides ${scenario.runwayMonths} months runway (may be over-capitalized)`);
+  } else {
+    reasons.push(`provides ${scenario.runwayMonths} months runway`);
+  }
+  
+  // Dilution analysis
+  if (scenario.dilutionPercent <= 0.15) {
+    reasons.push(`minimal dilution at ${(scenario.dilutionPercent * 100).toFixed(1)}%`);
+  } else if (scenario.dilutionPercent <= 0.25) {
+    reasons.push(`moderate dilution at ${(scenario.dilutionPercent * 100).toFixed(1)}%`);
+  } else {
+    reasons.push(`significant dilution at ${(scenario.dilutionPercent * 100).toFixed(1)}%`);
+  }
+  
+  // Valuation context
+  const formatter = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  });
+  reasons.push(`post-money valuation of ${formatter.format(scenario.postMoneyValuation)}`);
+  
+  return `Recommended: $${(scenario.raiseAmount / 1000).toFixed(0)}K raise - ${reasons.join(', ')}.`;
+}
+
+/**
+ * Build complete raise scenario comparison matrix
+ */
+export function buildRaiseScenarioMatrix(
+  burnRate: BurnRateComponents,
+  currentCash: number,
+  preMoneyValuation: number = DEFAULT_PRE_MONEY_VALUATION,
+  raiseAmounts: number[] = DEFAULT_RAISE_AMOUNTS,
+  instrument: RaiseScenarioInput['instrument'] = 'equity',
+  founderCurrentOwnership: number = FOUNDER_STARTING_OWNERSHIP
+): RaiseScenarioMatrix {
+  // Calculate all scenarios
+  const scenarios = raiseAmounts.map((amount) =>
+    calculateRaiseScenario(
+      {
+        raiseAmount: amount,
+        instrument,
+        preMoneyValuation,
+      },
+      burnRate,
+      currentCash,
+      founderCurrentOwnership
+    )
+  );
+  
+  // Find best scenario based on scoring
+  const scoredScenarios = scenarios.map((s) => ({
+    scenario: s,
+    score: scoreScenario(s),
+  }));
+  
+  const bestScored = scoredScenarios.reduce((best, current) =>
+    current.score > best.score ? current : best
+  );
+  
+  const recommendedScenario = bestScored.scenario;
+  const recommendationReason = generateRecommendation(recommendedScenario);
+  
+  return {
+    scenarios,
+    burnRate,
+    currentCash,
+    recommendedScenario,
+    recommendationReason,
+  };
+}
+
+/**
+ * Format currency for display
+ */
+export function formatRaiseCurrency(value: number): string {
+  if (value >= 1_000_000) {
+    return `$${(value / 1_000_000).toFixed(2)}M`;
+  }
+  if (value >= 1_000) {
+    return `$${(value / 1_000).toFixed(0)}K`;
+  }
+  return `$${value.toFixed(0)}`;
+}
+
+/**
+ * Format percentage for display
+ */
+export function formatRaisePercent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}

--- a/src/models/raise/index.ts
+++ b/src/models/raise/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Raise Scenario Module
+ * 
+ * Capital raise scenario analysis and comparison tools.
+ */
+
+export type {
+  RaiseInstrument,
+  SAFETerms,
+  ConvertibleDebtTerms,
+  EquityTerms,
+  RaiseScenarioInput,
+  BurnRateComponents,
+  RaiseScenarioResult,
+  RaiseScenarioMatrix,
+} from './types';
+
+export {
+  DEFAULT_RAISE_AMOUNTS,
+  DEFAULT_PRE_MONEY_VALUATION,
+  FOUNDER_STARTING_OWNERSHIP,
+} from './types';
+
+export {
+  calculateDilution,
+  calculateRunway,
+  assessRunwayRisk,
+  calculateBurnRate,
+  calculateRaiseScenario,
+  buildRaiseScenarioMatrix,
+  formatRaiseCurrency,
+  formatRaisePercent,
+} from './calculator';

--- a/src/models/raise/types.ts
+++ b/src/models/raise/types.ts
@@ -1,0 +1,118 @@
+/**
+ * Raise Scenario Types
+ * 
+ * Types for capital raise scenario analysis and comparison.
+ * Supports equity, SAFE, and convertible debt instruments.
+ */
+
+/**
+ * Type of capital raise instrument
+ */
+export type RaiseInstrument = 'equity' | 'safe' | 'convertible_debt';
+
+/**
+ * SAFE-specific terms
+ */
+export interface SAFETerms {
+  valuationCap: number;        // Maximum valuation for conversion
+  discountRate: number;        // Discount to next round price (e.g., 0.20 = 20%)
+  mfnClause: boolean;          // Most Favored Nation clause
+  proRataRights: boolean;      // Right to participate in future rounds
+}
+
+/**
+ * Convertible debt terms
+ */
+export interface ConvertibleDebtTerms {
+  interestRate: number;        // Annual interest rate (e.g., 0.06 = 6%)
+  maturityMonths: number;      // Months until maturity
+  valuationCap: number;        // Cap for conversion
+  discountRate: number;        // Discount to conversion price
+}
+
+/**
+ * Equity round terms
+ */
+export interface EquityTerms {
+  preMoneyValuation: number;   // Pre-money valuation
+  optionPoolIncrease: number;  // Additional option pool as % (e.g., 0.10 = 10%)
+  liquidationPreference: number; // Multiple (1 = 1x, 2 = 2x)
+  participating: boolean;       // Participating preferred
+}
+
+/**
+ * Input for a single raise scenario
+ */
+export interface RaiseScenarioInput {
+  raiseAmount: number;         // Amount to raise ($)
+  instrument: RaiseInstrument; // Type of instrument
+  preMoneyValuation: number;   // Pre-money valuation (for equity or conversion)
+  
+  // Instrument-specific terms (optional based on instrument type)
+  safeTerms?: SAFETerms;
+  convertibleTerms?: ConvertibleDebtTerms;
+  equityTerms?: EquityTerms;
+}
+
+/**
+ * Monthly burn rate components
+ */
+export interface BurnRateComponents {
+  payroll: number;             // Monthly payroll cost
+  marketing: number;           // Monthly marketing spend
+  operations: number;          // Rent, software, insurance, etc.
+  cogs: number;                // Variable costs (if any pre-revenue sales)
+  total: number;               // Total monthly burn
+}
+
+/**
+ * Output metrics for a single raise scenario
+ */
+export interface RaiseScenarioResult {
+  // Input echo
+  raiseAmount: number;
+  instrument: RaiseInstrument;
+  preMoneyValuation: number;
+  
+  // Calculated metrics
+  postMoneyValuation: number;  // Pre-money + raise amount
+  dilutionPercent: number;     // Ownership given up (as decimal, e.g., 0.20 = 20%)
+  runwayMonths: number;        // Months of runway at current burn
+  
+  // Ownership breakdown
+  founderOwnershipPost: number;   // Founder ownership % after raise
+  investorOwnershipPost: number;  // New investor ownership %
+  
+  // Per-dollar metrics
+  dilutionPerDollar: number;      // Dilution % per $100k raised
+  monthsPerDollar: number;        // Runway months per $100k raised
+  
+  // Risk assessment
+  runwayRiskLevel: 'critical' | 'low' | 'moderate' | 'comfortable' | 'extended';
+}
+
+/**
+ * Full comparison matrix result
+ */
+export interface RaiseScenarioMatrix {
+  scenarios: RaiseScenarioResult[];
+  burnRate: BurnRateComponents;
+  currentCash: number;
+  recommendedScenario: RaiseScenarioResult | null;
+  recommendationReason: string;
+}
+
+/**
+ * Default raise amounts for comparison matrix
+ */
+export const DEFAULT_RAISE_AMOUNTS = [100_000, 250_000, 500_000, 1_000_000];
+
+/**
+ * Default pre-money valuation if not specified
+ */
+export const DEFAULT_PRE_MONEY_VALUATION = 2_000_000;
+
+/**
+ * Founder starting ownership (before any raises)
+ */
+export const FOUNDER_STARTING_OWNERSHIP = 1.0; // 100%


### PR DESCRIPTION
## Summary
Build capital raise scenario comparison matrix for Issue #17.

## Changes
- **Types** (`src/models/raise/types.ts`): Define raise scenario types supporting equity, SAFE, and convertible debt instruments
- **Calculator** (`src/models/raise/calculator.ts`): Build calculation functions for dilution, runway, valuation impact, and optimal raise recommendations
- **Tests** (`src/models/raise/__tests__/raise.test.ts`): 26 comprehensive tests covering all calculator functions
- **Component** (`src/capital/RaiseScenarioMatrix.tsx`): Interactive matrix visualization

## Features
- Matrix comparing $100K, $250K, $500K, $1M raises
- Metrics: Dilution %, Runway months, Post-money valuation, Founder ownership %
- Optimal raise recommendation with reasoning
- Risk level indicators (critical → extended)
- Toggle between card and table views
- Dilution vs runway trade-off chart
- Configurable inputs: pre-money valuation, current cash, monthly burn rate, instrument type

## Screenshots
_Run `npm run dev` and navigate to /capital to see the component_

## Testing
```bash
npm test -- src/models/raise/__tests__/raise.test.ts
# 26 tests pass
```

Closes #17