### PR TITLE
feat(cogs): Separate line items for freight and packaging

### DIFF
--- a/src/costs/Costs.tsx
+++ b/src/costs/Costs.tsx
@@ -1,10 +1,12 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { KPICard } from '../components/KPICard'
 import { CostBreakdownChart } from '../components/charts/CostBreakdownChart'
 import { PermissionGate } from '../auth'
 import { useScenarioStore } from '../stores/scenarioStore'
 import { useGnaStore } from '../stores/gnaStore'
+import { useAssumptionsStore } from '../stores/assumptionsStore'
 import { getAnnualProjections } from '../models/adoption'
+import { calculateCOGSBreakdown, type COGSBreakdownResult } from '../models/cogs'
 
 // Format currency values for display
 const formatCurrency = (value: number): string => {
@@ -16,24 +18,67 @@ const formatCurrency = (value: number): string => {
   return `$${value.toFixed(0)}`
 }
 
-// COGS breakdown table component
-function COGSTable({ cogs, units }: { cogs: number; units: number }) {
-  const unitCost = 200
-  const materials = unitCost * 0.6
-  const labor = unitCost * 0.25
-  const overhead = unitCost * 0.15
+// Category colors for the breakdown
+const categoryColors: Record<string, string> = {
+  manufacturing: 'bg-blue-100 text-blue-800',
+  freight: 'bg-amber-100 text-amber-800',
+  packaging: 'bg-green-100 text-green-800',
+  duties: 'bg-purple-100 text-purple-800',
+}
 
-  const cogsBreakdown = [
-    { category: 'Raw Materials', perUnit: materials, total: units * materials },
-    { category: 'Direct Labor', perUnit: labor, total: units * labor },
-    { category: 'Manufacturing Overhead', perUnit: overhead, total: units * overhead },
-  ]
+// Category icons
+const categoryIcons: Record<string, string> = {
+  manufacturing: '🏭',
+  freight: '🚢',
+  packaging: '📦',
+  duties: '📋',
+}
 
+// COGS breakdown table component with configurable line items
+function COGSTable({ breakdown, units }: { breakdown: COGSBreakdownResult; units: number }) {
   return (
     <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
-      <h3 className="text-lg font-semibold text-gray-900 mb-4">
-        Cost of Goods Sold (COGS)
-      </h3>
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-gray-900">
+          Cost of Goods Sold (COGS)
+        </h3>
+        <span className="text-sm text-gray-500">
+          {units.toLocaleString()} units projected
+        </span>
+      </div>
+      
+      {/* Visual breakdown bars */}
+      <div className="mb-6">
+        <div className="flex h-4 rounded-full overflow-hidden">
+          {breakdown.lineItems.map((item) => (
+            <div
+              key={item.category}
+              className={`${
+                item.category === 'manufacturing' ? 'bg-blue-500' :
+                item.category === 'freight' ? 'bg-amber-500' :
+                item.category === 'packaging' ? 'bg-green-500' : 'bg-purple-500'
+              }`}
+              style={{ width: `${item.percentage}%` }}
+              title={`${item.name}: ${item.percentage.toFixed(1)}%`}
+            />
+          ))}
+        </div>
+        <div className="flex justify-between mt-2 text-xs text-gray-500">
+          {breakdown.lineItems.map((item) => (
+            <div key={item.category} className="flex items-center gap-1">
+              <span
+                className={`w-2 h-2 rounded-full ${
+                  item.category === 'manufacturing' ? 'bg-blue-500' :
+                  item.category === 'freight' ? 'bg-amber-500' :
+                  item.category === 'packaging' ? 'bg-green-500' : 'bg-purple-500'
+                }`}
+              />
+              <span>{item.percentage.toFixed(0)}%</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
       <div className="overflow-x-auto">
         <table className="min-w-full divide-y divide-gray-200">
           <thead>
@@ -45,16 +90,30 @@ function COGSTable({ cogs, units }: { cogs: number; units: number }) {
                 Per Unit
               </th>
               <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                Total ({units.toLocaleString()} units)
+                % of COGS
+              </th>
+              <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Total
               </th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-100">
-            {cogsBreakdown.map((item) => (
+            {breakdown.lineItems.map((item) => (
               <tr key={item.category} className="hover:bg-gray-50">
-                <td className="px-4 py-3 text-sm text-gray-900">{item.category}</td>
+                <td className="px-4 py-3 text-sm text-gray-900">
+                  <div className="flex items-center gap-2">
+                    <span>{categoryIcons[item.category]}</span>
+                    <span>{item.name}</span>
+                    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${categoryColors[item.category]}`}>
+                      {item.category}
+                    </span>
+                  </div>
+                </td>
                 <td className="px-4 py-3 text-sm text-gray-600 text-right">
                   ${item.perUnit.toFixed(2)}
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-600 text-right">
+                  {item.percentage.toFixed(1)}%
                 </td>
                 <td className="px-4 py-3 text-sm text-gray-900 text-right font-medium">
                   {formatCurrency(item.total)}
@@ -68,14 +127,123 @@ function COGSTable({ cogs, units }: { cogs: number; units: number }) {
                 Total COGS
               </td>
               <td className="px-4 py-3 text-sm font-semibold text-gray-900 text-right">
-                $200.00
+                ${breakdown.totalPerUnit.toFixed(2)}
               </td>
               <td className="px-4 py-3 text-sm font-semibold text-gray-900 text-right">
-                {formatCurrency(cogs)}
+                100%
+              </td>
+              <td className="px-4 py-3 text-sm font-semibold text-gray-900 text-right">
+                {formatCurrency(breakdown.totalCost)}
               </td>
             </tr>
           </tfoot>
         </table>
+      </div>
+    </div>
+  )
+}
+
+// COGS Configuration Panel
+function COGSConfigPanel({ 
+  config, 
+  onUpdate 
+}: { 
+  config: {
+    manufacturingCost: number;
+    freightCost: number;
+    packagingCost: number;
+    dutiesCost: number;
+  };
+  onUpdate: (updates: Partial<typeof config>) => void;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [localConfig, setLocalConfig] = useState(config);
+
+  const handleSave = () => {
+    onUpdate(localConfig);
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setLocalConfig(config);
+    setIsEditing(false);
+  };
+
+  const totalCost = localConfig.manufacturingCost + localConfig.freightCost + 
+                    localConfig.packagingCost + localConfig.dutiesCost;
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-gray-900">
+          COGS Configuration
+        </h3>
+        {!isEditing ? (
+          <button
+            onClick={() => setIsEditing(true)}
+            className="text-sm text-blue-600 hover:text-blue-800 font-medium"
+          >
+            Edit Costs
+          </button>
+        ) : (
+          <div className="flex gap-2">
+            <button
+              onClick={handleCancel}
+              className="text-sm text-gray-600 hover:text-gray-800 font-medium"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSave}
+              className="text-sm text-white bg-blue-600 hover:bg-blue-700 px-3 py-1 rounded-md font-medium"
+            >
+              Save
+            </button>
+          </div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {[
+          { key: 'manufacturingCost', label: 'Manufacturing', icon: '🏭', bgColor: 'bg-blue-50', borderColor: 'border-blue-100' },
+          { key: 'freightCost', label: 'Freight', icon: '🚢', bgColor: 'bg-amber-50', borderColor: 'border-amber-100' },
+          { key: 'packagingCost', label: 'Packaging', icon: '📦', bgColor: 'bg-green-50', borderColor: 'border-green-100' },
+          { key: 'dutiesCost', label: 'Import Duties', icon: '📋', bgColor: 'bg-purple-50', borderColor: 'border-purple-100' },
+        ].map(({ key, label, icon, bgColor, borderColor }) => (
+          <div key={key} className={`p-4 rounded-lg ${bgColor} border ${borderColor}`}>
+            <div className="flex items-center gap-2 mb-2">
+              <span>{icon}</span>
+              <span className="text-sm font-medium text-gray-700">{label}</span>
+            </div>
+            {isEditing ? (
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">$</span>
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={localConfig[key as keyof typeof localConfig]}
+                  onChange={(e) => setLocalConfig({
+                    ...localConfig,
+                    [key]: parseFloat(e.target.value) || 0,
+                  })}
+                  className="w-full pl-7 pr-3 py-2 border border-gray-300 rounded-md text-right font-mono"
+                />
+              </div>
+            ) : (
+              <p className="text-2xl font-bold text-gray-900">
+                ${config[key as keyof typeof config].toFixed(2)}
+              </p>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-4 p-3 bg-gray-100 rounded-lg flex items-center justify-between">
+        <span className="font-medium text-gray-700">Total COGS per Unit</span>
+        <span className={`text-xl font-bold ${isEditing && totalCost !== config.manufacturingCost + config.freightCost + config.packagingCost + config.dutiesCost ? 'text-amber-600' : 'text-gray-900'}`}>
+          ${totalCost.toFixed(2)}
+        </span>
       </div>
     </div>
   )
@@ -165,12 +333,19 @@ function SalaryTable() {
 export function Costs() {
   const { selectedScenarioId, scenarios } = useScenarioStore()
   const selectedScenario = scenarios.find((s) => s.id === selectedScenarioId)
+  const { cogs: cogsConfig, updateCOGS } = useAssumptionsStore()
 
-  // Calculate costs based on scenario
+  // Calculate costs based on scenario and COGS config
   const costData = useMemo(() => {
     const units = getAnnualProjections(selectedScenarioId, 2025, 1)[0]
-    const unitCost = 200
-    const cogs = units * unitCost
+    
+    // Calculate COGS breakdown using the new model
+    const cogsBreakdown = calculateCOGSBreakdown(units, {
+      manufacturingCost: cogsConfig.manufacturingCost,
+      freightCost: cogsConfig.freightCost,
+      packagingCost: cogsConfig.packagingCost,
+      dutiesCost: cogsConfig.dutiesCost,
+    })
 
     const revenue = units * 1000
     const marketingBase = 30000
@@ -179,16 +354,17 @@ export function Costs() {
 
     const gna = 50000
 
-    const totalCosts = cogs + marketing + gna
+    const totalCosts = cogsBreakdown.totalCost + marketing + gna
 
     return {
       units,
-      cogs,
+      cogs: cogsBreakdown.totalCost,
+      cogsBreakdown,
       marketing,
       gna,
       totalCosts,
     }
-  }, [selectedScenarioId])
+  }, [selectedScenarioId, cogsConfig])
 
   return (
     <div className="space-y-6">
@@ -244,8 +420,24 @@ export function Costs() {
         </div>
       </div>
 
-      {/* COGS Table */}
-      <COGSTable cogs={costData.cogs} units={costData.units} />
+      {/* COGS Configuration */}
+      <PermissionGate
+        permission="edit:costs"
+        fallback={null}
+      >
+        <COGSConfigPanel
+          config={{
+            manufacturingCost: cogsConfig.manufacturingCost,
+            freightCost: cogsConfig.freightCost,
+            packagingCost: cogsConfig.packagingCost,
+            dutiesCost: cogsConfig.dutiesCost,
+          }}
+          onUpdate={(updates) => updateCOGS(updates)}
+        />
+      </PermissionGate>
+
+      {/* COGS Breakdown Table */}
+      <COGSTable breakdown={costData.cogsBreakdown} units={costData.units} />
 
       {/* G&A Section with Salary Gate */}
       <div className="space-y-4">

--- a/src/models/assumptions/defaults.ts
+++ b/src/models/assumptions/defaults.ts
@@ -19,6 +19,12 @@ export const DEFAULT_COGS: COGSAssumptions = {
   unitCost: 200,
   costReductionPerYear: 0.05,
   shippingPerUnit: 25,
+  
+  // Separated COGS line items (sum = unitCost)
+  manufacturingCost: 140,        // 70% of unit cost
+  freightCost: 35,               // Overseas freight/transport
+  packagingCost: 15,             // Box, inserts, materials
+  dutiesCost: 10,                // Import duties
 };
 
 export const DEFAULT_MARKETING: MarketingAssumptions = {

--- a/src/models/assumptions/types.ts
+++ b/src/models/assumptions/types.ts
@@ -5,9 +5,15 @@ export interface RevenueAssumptions {
 }
 
 export interface COGSAssumptions {
-  unitCost: number;              // Default $200
+  unitCost: number;              // Default $200 (total, kept for backwards compatibility)
   costReductionPerYear: number;  // Default 5% (scale economies)
-  shippingPerUnit: number;       // Default $25
+  shippingPerUnit: number;       // Default $25 (outbound to customer)
+  
+  // Separated COGS line items
+  manufacturingCost: number;     // Manufacturing cost per unit (Default $140)
+  freightCost: number;           // Overseas freight/transport per unit (Default $35)
+  packagingCost: number;         // Box, inserts, materials per unit (Default $15)
+  dutiesCost: number;            // Import duties per unit (Default $10)
 }
 
 export interface MarketingAssumptions {

--- a/src/models/cogs/__tests__/breakdown.test.ts
+++ b/src/models/cogs/__tests__/breakdown.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculateCOGSBreakdown,
+  createBreakdownCalculator,
+  applyCostReduction,
+  projectCOGSBreakdown,
+  DEFAULT_COGS_BREAKDOWN,
+} from '../breakdown';
+import type { COGSBreakdownConfig } from '../types';
+
+describe('COGS Breakdown', () => {
+  describe('calculateCOGSBreakdown', () => {
+    it('calculates breakdown with default config at 1000 units', () => {
+      const result = calculateCOGSBreakdown(1000);
+      
+      expect(result.volume).toBe(1000);
+      expect(result.totalPerUnit).toBe(200);
+      expect(result.totalCost).toBe(200000);
+      expect(result.lineItems).toHaveLength(4);
+    });
+
+    it('returns correct line items', () => {
+      const result = calculateCOGSBreakdown(100);
+      
+      const manufacturing = result.lineItems.find(li => li.category === 'manufacturing');
+      const freight = result.lineItems.find(li => li.category === 'freight');
+      const packaging = result.lineItems.find(li => li.category === 'packaging');
+      const duties = result.lineItems.find(li => li.category === 'duties');
+
+      expect(manufacturing?.perUnit).toBe(140);
+      expect(manufacturing?.total).toBe(14000);
+      expect(manufacturing?.percentage).toBe(70);
+
+      expect(freight?.perUnit).toBe(35);
+      expect(freight?.total).toBe(3500);
+      expect(freight?.percentage).toBe(17.5);
+
+      expect(packaging?.perUnit).toBe(15);
+      expect(packaging?.total).toBe(1500);
+      expect(packaging?.percentage).toBe(7.5);
+
+      expect(duties?.perUnit).toBe(10);
+      expect(duties?.total).toBe(1000);
+      expect(duties?.percentage).toBe(5);
+    });
+
+    it('calculates summary totals correctly', () => {
+      const result = calculateCOGSBreakdown(500);
+      
+      expect(result.summary.manufacturing).toBe(70000);
+      expect(result.summary.freight).toBe(17500);
+      expect(result.summary.packaging).toBe(7500);
+      expect(result.summary.duties).toBe(5000);
+      
+      const summaryTotal = 
+        result.summary.manufacturing +
+        result.summary.freight +
+        result.summary.packaging +
+        result.summary.duties;
+      expect(summaryTotal).toBe(result.totalCost);
+    });
+
+    it('uses custom configuration', () => {
+      const customConfig: COGSBreakdownConfig = {
+        manufacturingCost: 100,
+        freightCost: 50,
+        packagingCost: 30,
+        dutiesCost: 20,
+      };
+      
+      const result = calculateCOGSBreakdown(100, customConfig);
+      
+      expect(result.totalPerUnit).toBe(200);
+      expect(result.totalCost).toBe(20000);
+      expect(result.summary.manufacturing).toBe(10000);
+      expect(result.summary.freight).toBe(5000);
+    });
+
+    it('throws error for zero volume', () => {
+      expect(() => calculateCOGSBreakdown(0)).toThrow('Volume must be greater than 0');
+    });
+
+    it('throws error for negative volume', () => {
+      expect(() => calculateCOGSBreakdown(-100)).toThrow('Volume must be greater than 0');
+    });
+
+    it('handles partial config override', () => {
+      const result = calculateCOGSBreakdown(100, { freightCost: 50 });
+      
+      const freight = result.lineItems.find(li => li.category === 'freight');
+      expect(freight?.perUnit).toBe(50);
+      
+      // Other values should still be defaults
+      const manufacturing = result.lineItems.find(li => li.category === 'manufacturing');
+      expect(manufacturing?.perUnit).toBe(140);
+    });
+  });
+
+  describe('createBreakdownCalculator', () => {
+    it('creates a reusable calculator with fixed config', () => {
+      const calculator = createBreakdownCalculator({
+        manufacturingCost: 80,
+        freightCost: 20,
+        packagingCost: 10,
+        dutiesCost: 5,
+      });
+
+      const result = calculator(1000);
+      expect(result.totalPerUnit).toBe(115);
+      expect(result.totalCost).toBe(115000);
+    });
+
+    it('uses default config when none provided', () => {
+      const calculator = createBreakdownCalculator();
+      const result = calculator(100);
+      
+      expect(result.totalPerUnit).toBe(200);
+    });
+  });
+
+  describe('applyCostReduction', () => {
+    it('applies 5% reduction to costs (except duties)', () => {
+      const original: COGSBreakdownConfig = {
+        manufacturingCost: 100,
+        freightCost: 40,
+        packagingCost: 20,
+        dutiesCost: 10,
+      };
+
+      const reduced = applyCostReduction(original, 0.05);
+
+      expect(reduced.manufacturingCost).toBe(95);
+      expect(reduced.freightCost).toBe(38);
+      expect(reduced.packagingCost).toBe(19);
+      expect(reduced.dutiesCost).toBe(10); // Duties unchanged
+    });
+
+    it('handles 10% reduction', () => {
+      const result = applyCostReduction(DEFAULT_COGS_BREAKDOWN, 0.10);
+      
+      expect(result.manufacturingCost).toBe(126);
+      expect(result.freightCost).toBe(31.5);
+      expect(result.packagingCost).toBe(13.5);
+      expect(result.dutiesCost).toBe(10);
+    });
+
+    it('handles zero reduction', () => {
+      const result = applyCostReduction(DEFAULT_COGS_BREAKDOWN, 0);
+      
+      expect(result.manufacturingCost).toBe(140);
+      expect(result.freightCost).toBe(35);
+      expect(result.packagingCost).toBe(15);
+      expect(result.dutiesCost).toBe(10);
+    });
+  });
+
+  describe('projectCOGSBreakdown', () => {
+    it('projects costs over multiple years with reduction', () => {
+      const volumes = [1000, 2000, 3000];
+      const results = projectCOGSBreakdown(volumes);
+
+      expect(results).toHaveLength(3);
+      
+      // Year 1: no reduction
+      expect(results[0].totalPerUnit).toBe(200);
+      expect(results[0].totalCost).toBe(200000);
+
+      // Year 2: 5% reduction (except duties)
+      expect(results[1].totalPerUnit).toBeLessThan(200);
+      expect(results[1].volume).toBe(2000);
+
+      // Year 3: another 5% reduction
+      expect(results[2].totalPerUnit).toBeLessThan(results[1].totalPerUnit);
+    });
+
+    it('applies custom reduction rate', () => {
+      const volumes = [1000, 1000];
+      const results = projectCOGSBreakdown(volumes, {}, 0.10);
+
+      // Year 2 should have 10% lower costs (except duties)
+      const year1Manufacturing = results[0].lineItems.find(li => li.category === 'manufacturing')!;
+      const year2Manufacturing = results[1].lineItems.find(li => li.category === 'manufacturing')!;
+      
+      expect(year2Manufacturing.perUnit).toBe(year1Manufacturing.perUnit * 0.9);
+    });
+
+    it('uses custom base config', () => {
+      const volumes = [1000];
+      const results = projectCOGSBreakdown(volumes, { manufacturingCost: 100 });
+
+      const manufacturing = results[0].lineItems.find(li => li.category === 'manufacturing');
+      expect(manufacturing?.perUnit).toBe(100);
+    });
+  });
+
+  describe('DEFAULT_COGS_BREAKDOWN', () => {
+    it('sums to $200 total', () => {
+      const total = 
+        DEFAULT_COGS_BREAKDOWN.manufacturingCost +
+        DEFAULT_COGS_BREAKDOWN.freightCost +
+        DEFAULT_COGS_BREAKDOWN.packagingCost +
+        DEFAULT_COGS_BREAKDOWN.dutiesCost;
+      
+      expect(total).toBe(200);
+    });
+
+    it('has reasonable proportions', () => {
+      // Manufacturing should be the largest component
+      expect(DEFAULT_COGS_BREAKDOWN.manufacturingCost).toBeGreaterThan(
+        DEFAULT_COGS_BREAKDOWN.freightCost
+      );
+      expect(DEFAULT_COGS_BREAKDOWN.manufacturingCost).toBeGreaterThan(
+        DEFAULT_COGS_BREAKDOWN.packagingCost
+      );
+      expect(DEFAULT_COGS_BREAKDOWN.manufacturingCost).toBeGreaterThan(
+        DEFAULT_COGS_BREAKDOWN.dutiesCost
+      );
+    });
+  });
+});

--- a/src/models/cogs/breakdown.ts
+++ b/src/models/cogs/breakdown.ts
@@ -1,0 +1,139 @@
+/**
+ * COGS Breakdown Calculator
+ *
+ * Calculates detailed COGS breakdown with separate line items for:
+ * - Manufacturing cost
+ * - Overseas freight
+ * - Packaging (box, inserts, materials)
+ * - Import duties
+ */
+
+import type { COGSBreakdownConfig, COGSBreakdownResult, COGSLineItem } from './types';
+
+/** Default COGS breakdown configuration (sums to $200) */
+export const DEFAULT_COGS_BREAKDOWN: COGSBreakdownConfig = {
+  manufacturingCost: 140,  // 70%
+  freightCost: 35,         // 17.5%
+  packagingCost: 15,       // 7.5%
+  dutiesCost: 10,          // 5%
+};
+
+/**
+ * Calculate the COGS breakdown for a given volume
+ */
+export function calculateCOGSBreakdown(
+  volume: number,
+  config: Partial<COGSBreakdownConfig> = {}
+): COGSBreakdownResult {
+  if (volume <= 0) {
+    throw new Error('Volume must be greater than 0');
+  }
+
+  const fullConfig: COGSBreakdownConfig = {
+    ...DEFAULT_COGS_BREAKDOWN,
+    ...config,
+  };
+
+  const totalPerUnit =
+    fullConfig.manufacturingCost +
+    fullConfig.freightCost +
+    fullConfig.packagingCost +
+    fullConfig.dutiesCost;
+
+  const totalCost = volume * totalPerUnit;
+
+  // Calculate line items with percentages
+  const lineItems: COGSLineItem[] = [
+    {
+      category: 'manufacturing',
+      name: 'Manufacturing Cost',
+      perUnit: fullConfig.manufacturingCost,
+      total: volume * fullConfig.manufacturingCost,
+      percentage: totalPerUnit > 0 ? (fullConfig.manufacturingCost / totalPerUnit) * 100 : 0,
+    },
+    {
+      category: 'freight',
+      name: 'Overseas Freight',
+      perUnit: fullConfig.freightCost,
+      total: volume * fullConfig.freightCost,
+      percentage: totalPerUnit > 0 ? (fullConfig.freightCost / totalPerUnit) * 100 : 0,
+    },
+    {
+      category: 'packaging',
+      name: 'Packaging & Materials',
+      perUnit: fullConfig.packagingCost,
+      total: volume * fullConfig.packagingCost,
+      percentage: totalPerUnit > 0 ? (fullConfig.packagingCost / totalPerUnit) * 100 : 0,
+    },
+    {
+      category: 'duties',
+      name: 'Import Duties',
+      perUnit: fullConfig.dutiesCost,
+      total: volume * fullConfig.dutiesCost,
+      percentage: totalPerUnit > 0 ? (fullConfig.dutiesCost / totalPerUnit) * 100 : 0,
+    },
+  ];
+
+  return {
+    volume,
+    lineItems,
+    totalPerUnit,
+    totalCost,
+    summary: {
+      manufacturing: volume * fullConfig.manufacturingCost,
+      freight: volume * fullConfig.freightCost,
+      packaging: volume * fullConfig.packagingCost,
+      duties: volume * fullConfig.dutiesCost,
+    },
+  };
+}
+
+/**
+ * Create a breakdown calculator with fixed configuration
+ */
+export function createBreakdownCalculator(config: Partial<COGSBreakdownConfig> = {}) {
+  const fullConfig: COGSBreakdownConfig = {
+    ...DEFAULT_COGS_BREAKDOWN,
+    ...config,
+  };
+
+  return (volume: number) => calculateCOGSBreakdown(volume, fullConfig);
+}
+
+/**
+ * Apply cost reduction to COGS breakdown config
+ * Used for year-over-year scale economy calculations
+ */
+export function applyCostReduction(
+  config: COGSBreakdownConfig,
+  reductionRate: number
+): COGSBreakdownConfig {
+  const factor = 1 - reductionRate;
+  return {
+    manufacturingCost: Math.round(config.manufacturingCost * factor * 100) / 100,
+    freightCost: Math.round(config.freightCost * factor * 100) / 100,
+    packagingCost: Math.round(config.packagingCost * factor * 100) / 100,
+    dutiesCost: config.dutiesCost, // Duties typically don't benefit from scale
+  };
+}
+
+/**
+ * Calculate multi-year COGS projection with cost reduction
+ */
+export function projectCOGSBreakdown(
+  volumeByYear: number[],
+  baseConfig: Partial<COGSBreakdownConfig> = {},
+  annualCostReduction: number = 0.05
+): COGSBreakdownResult[] {
+  let currentConfig: COGSBreakdownConfig = {
+    ...DEFAULT_COGS_BREAKDOWN,
+    ...baseConfig,
+  };
+
+  return volumeByYear.map((volume, yearIndex) => {
+    if (yearIndex > 0) {
+      currentConfig = applyCostReduction(currentConfig, annualCostReduction);
+    }
+    return calculateCOGSBreakdown(volume, currentConfig);
+  });
+}

--- a/src/models/cogs/index.ts
+++ b/src/models/cogs/index.ts
@@ -1,7 +1,7 @@
 /**
  * COGS (Cost of Goods Sold) Module
  *
- * Provides volume-based cost interpolation for pricing calculations.
+ * Provides volume-based cost interpolation and breakdown calculations.
  */
 
 export * from './types';
@@ -11,3 +11,10 @@ export {
   calculateCost,
   interpolate,
 } from './interpolation';
+export {
+  DEFAULT_COGS_BREAKDOWN,
+  calculateCOGSBreakdown,
+  createBreakdownCalculator,
+  applyCostReduction,
+  projectCOGSBreakdown,
+} from './breakdown';

--- a/src/models/cogs/types.ts
+++ b/src/models/cogs/types.ts
@@ -35,3 +35,54 @@ export interface CostCalculationResult {
   /** Whether the result hit the minimum cost floor */
   atFloor: boolean;
 }
+
+/**
+ * Individual COGS line item breakdown
+ */
+export interface COGSLineItem {
+  /** Category identifier */
+  category: 'manufacturing' | 'freight' | 'packaging' | 'duties';
+  /** Display name */
+  name: string;
+  /** Cost per unit in dollars */
+  perUnit: number;
+  /** Total cost for volume */
+  total: number;
+  /** Percentage of total COGS */
+  percentage: number;
+}
+
+/**
+ * Configuration for COGS breakdown calculation
+ */
+export interface COGSBreakdownConfig {
+  /** Manufacturing/production cost per unit */
+  manufacturingCost: number;
+  /** Overseas freight/transport cost per unit */
+  freightCost: number;
+  /** Packaging cost per unit (box, inserts, materials) */
+  packagingCost: number;
+  /** Import duties per unit (if applicable) */
+  dutiesCost: number;
+}
+
+/**
+ * Result of a full COGS breakdown calculation
+ */
+export interface COGSBreakdownResult {
+  /** Number of units */
+  volume: number;
+  /** Individual line items */
+  lineItems: COGSLineItem[];
+  /** Total cost per unit across all categories */
+  totalPerUnit: number;
+  /** Total cost for the volume */
+  totalCost: number;
+  /** Summary by category */
+  summary: {
+    manufacturing: number;
+    freight: number;
+    packaging: number;
+    duties: number;
+  };
+}

--- a/src/stores/assumptionsStore.ts
+++ b/src/stores/assumptionsStore.ts
@@ -155,9 +155,13 @@ export const useAssumptionsStore = create<AssumptionsStore>()(
         rows.push(`Revenue,Discount Rate,${(state.revenue.discountRate * 100).toFixed(1)}%`);
         
         // COGS
-        rows.push(`COGS,Unit Cost,$${state.cogs.unitCost}`);
+        rows.push(`COGS,Unit Cost (Total),$${state.cogs.unitCost}`);
         rows.push(`COGS,Cost Reduction/Year,${(state.cogs.costReductionPerYear * 100).toFixed(1)}%`);
         rows.push(`COGS,Shipping per Unit,$${state.cogs.shippingPerUnit}`);
+        rows.push(`COGS,Manufacturing Cost,$${state.cogs.manufacturingCost}`);
+        rows.push(`COGS,Freight Cost,$${state.cogs.freightCost}`);
+        rows.push(`COGS,Packaging Cost,$${state.cogs.packagingCost}`);
+        rows.push(`COGS,Import Duties,$${state.cogs.dutiesCost}`);
         
         // Marketing
         rows.push(`Marketing,Base Budget,$${state.marketing.baseBudget}`);


### PR DESCRIPTION
Closes #7

## Summary
Breaks out COGS into explicit, configurable components:
- **Manufacturing cost** ($140) - 70%
- **Overseas freight** ($35) - 17.5%
- **Packaging & materials** ($15) - 7.5%  
- **Import duties** ($10) - 5%

## Changes

### Model Layer
- New `COGSBreakdownConfig` and `COGSBreakdownResult` types
- `calculateCOGSBreakdown()` - calculates line items with percentages
- `applyCostReduction()` - year-over-year scale economies
- `projectCOGSBreakdown()` - multi-year COGS projections
- Updated `COGSAssumptions` with new breakdown fields

### UI
- New visual percentage bars showing COGS composition
- `COGSConfigPanel` - edit individual cost components
- Updated `COGSTable` - shows all 4 line items with totals
- Category icons and color-coded badges

### Tests
- 17 new unit tests for breakdown calculations
- Tests for edge cases, custom configs, and projections

## Screenshots
The Costs page now shows a visual breakdown bar and detailed table with:
- Per-unit cost for each category
- Percentage of total COGS
- Total cost based on projected volume

## Acceptance Criteria
- [x] Each component configurable
- [x] Total COGS calculation  
- [x] Historical tracking (via assumptions store)