### PR TITLE
feat(marketing): channel-based budget allocation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { Dashboard } from './dashboard/Dashboard'
 import { Projections } from './projections'
 import { Costs } from './costs'
 import { Revenue, RevenueByScenario } from './revenue'
-import { Marketing, LaunchPlan, EmailSequences, Campaigns, MarketingAnalytics, CACDashboard, ReferralProgram, VideoPlaybook, VideoIdeasBank, CompetitorResearch, VideoBriefTemplate } from './marketing'
+import { Marketing, LaunchPlan, EmailSequences, Campaigns, MarketingAnalytics, CACDashboard, ReferralProgram, VideoPlaybook, VideoIdeasBank, CompetitorResearch, VideoBriefTemplate, BudgetAllocationConfig } from './marketing'
 import { PreorderSettings } from './preorder'
 import { DepositConfiguration } from './preorder'
 import { FPADashboard, QuickBooksConnect, AccountMapping, Historicals, QBOActualsImport } from './fpa'
@@ -326,6 +326,18 @@ function App() {
                 <PermissionGate permission="view:marketing" fallback={<AccessDenied />}>
                   <Layout title="Video Brief">
                     <VideoBriefTemplate />
+                  </Layout>
+                </PermissionGate>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/marketing/budget"
+            element={
+              <ProtectedRoute>
+                <PermissionGate permission="view:marketing" fallback={<AccessDenied />}>
+                  <Layout title="Budget Allocation">
+                    <BudgetAllocationConfig />
                   </Layout>
                 </PermissionGate>
               </ProtectedRoute>

--- a/src/marketing/BudgetAllocationConfig.tsx
+++ b/src/marketing/BudgetAllocationConfig.tsx
@@ -1,0 +1,142 @@
+/**
+ * Budget Allocation Config
+ * Simple component for configuring marketing budget by channel
+ */
+
+import { useState } from 'react';
+import { useMarketingStore } from '../stores/marketingStore';
+
+export function BudgetAllocationConfig() {
+  const {
+    totalBudget,
+    setTotalBudget,
+    channels,
+    getChannelBudgets,
+    setChannelBudget,
+  } = useMarketingStore();
+
+  const [editingTotal, setEditingTotal] = useState(false);
+  const [tempTotal, setTempTotal] = useState(totalBudget.toString());
+
+  const channelBudgets = getChannelBudgets();
+  const activeChannels = channels.filter((ch) => ch.isActive);
+  const allocatedTotal = channelBudgets.reduce((sum, cb) => sum + cb.budget, 0);
+  const remaining = totalBudget - allocatedTotal;
+
+  const handleTotalSave = () => {
+    const value = parseFloat(tempTotal) || 0;
+    setTotalBudget(value);
+    setEditingTotal(false);
+  };
+
+  const handleBudgetChange = (channelId: string, value: string) => {
+    const budget = parseFloat(value) || 0;
+    setChannelBudget(channelId, budget);
+  };
+
+  const categoryGroups = activeChannels.reduce((acc, ch) => {
+    if (!acc[ch.category]) acc[ch.category] = [];
+    acc[ch.category].push(ch);
+    return acc;
+  }, {} as Record<string, typeof activeChannels>);
+
+  const categoryLabels: Record<string, string> = {
+    digital: '💻 Digital',
+    field: '🎪 Field',
+    influencer: '⭐ Influencer',
+    content: '📝 Content',
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900">Budget Allocation</h2>
+        <p className="text-gray-500 mt-1">Configure marketing budget by channel</p>
+      </div>
+
+      {/* Total Budget */}
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900">Total Marketing Budget</h3>
+            <p className="text-sm text-gray-500">Monthly budget across all channels</p>
+          </div>
+          {editingTotal ? (
+            <div className="flex items-center gap-2">
+              <span className="text-gray-500">$</span>
+              <input
+                type="number"
+                value={tempTotal}
+                onChange={(e) => setTempTotal(e.target.value)}
+                className="w-32 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                autoFocus
+              />
+              <button
+                onClick={handleTotalSave}
+                className="px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+              >
+                Save
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={() => {
+                setTempTotal(totalBudget.toString());
+                setEditingTotal(true);
+              }}
+              className="text-2xl font-bold text-gray-900 hover:text-blue-600"
+            >
+              ${totalBudget.toLocaleString()}
+            </button>
+          )}
+        </div>
+
+        {/* Allocation Summary */}
+        <div className="mt-4 flex gap-4 text-sm">
+          <div className="px-3 py-1 bg-green-100 text-green-800 rounded-full">
+            Allocated: ${allocatedTotal.toLocaleString()}
+          </div>
+          <div className={`px-3 py-1 rounded-full ${remaining >= 0 ? 'bg-blue-100 text-blue-800' : 'bg-red-100 text-red-800'}`}>
+            Remaining: ${remaining.toLocaleString()}
+          </div>
+        </div>
+      </div>
+
+      {/* Channel Budgets by Category */}
+      {Object.entries(categoryGroups).map(([category, categoryChannels]) => (
+        <div key={category} className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4">
+            {categoryLabels[category] || category}
+          </h3>
+          <div className="space-y-3">
+            {categoryChannels.map((channel) => {
+              const budget = channelBudgets.find((cb) => cb.channel === channel.id);
+              return (
+                <div key={channel.id} className="flex items-center justify-between">
+                  <div className="flex-1">
+                    <p className="font-medium text-gray-900">{channel.name}</p>
+                    <p className="text-sm text-gray-500">{channel.description}</p>
+                  </div>
+                  <div className="flex items-center gap-4">
+                    <div className="flex items-center gap-1">
+                      <span className="text-gray-500">$</span>
+                      <input
+                        type="number"
+                        value={budget?.budget || 0}
+                        onChange={(e) => handleBudgetChange(channel.id, e.target.value)}
+                        className="w-24 px-2 py-1 border border-gray-300 rounded-lg text-right focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      />
+                    </div>
+                    <span className="text-sm text-gray-500 w-16 text-right">
+                      {(budget?.percentage || 0).toFixed(1)}%
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/marketing/Marketing.tsx
+++ b/src/marketing/Marketing.tsx
@@ -12,6 +12,7 @@ const quickLinks = [
   { path: '/marketing/email', label: 'Email Sequences', icon: '📧', desc: 'Automated email campaigns' },
   { path: '/marketing/campaigns', label: 'Campaigns', icon: '🎯', desc: 'Track campaign performance' },
   { path: '/marketing/analytics', label: 'Analytics', icon: '📊', desc: 'Marketing metrics & ROI' },
+  { path: '/marketing/budget', label: 'Budget Allocation', icon: '💰', desc: 'Configure budget by channel' },
 ]
 
 export function Marketing() {

--- a/src/marketing/index.ts
+++ b/src/marketing/index.ts
@@ -8,5 +8,6 @@ export { ReferralProgram } from './ReferralProgram'
 export { VideoPlaybook } from './VideoPlaybook'
 export { VideoBriefTemplate } from './VideoBriefTemplate'
 export { CompetitorResearch } from './CompetitorResearch'
+export { BudgetAllocationConfig } from './BudgetAllocationConfig'
 import VideoIdeasBankDefault from './VideoIdeasBank'
 export const VideoIdeasBank = VideoIdeasBankDefault

--- a/src/models/marketing/index.ts
+++ b/src/models/marketing/index.ts
@@ -13,6 +13,7 @@ export type {
   CACResult,
   ROASResult,
   BudgetAllocation,
+  ChannelBudget,
   MarketingPerformance,
 } from './types';
 

--- a/src/models/marketing/types.ts
+++ b/src/models/marketing/types.ts
@@ -115,6 +115,19 @@ export interface BudgetAllocation {
 }
 
 /**
+ * Simple channel budget allocation
+ * Used for configuring budget by marketing channel
+ */
+export interface ChannelBudget {
+  /** Channel name or ID */
+  channel: string;
+  /** Allocated budget amount in dollars */
+  budget: number;
+  /** Percentage of total marketing budget (0-100) */
+  percentage: number;
+}
+
+/**
  * Marketing performance summary
  */
 export interface MarketingPerformance {

--- a/src/stores/marketingStore.ts
+++ b/src/stores/marketingStore.ts
@@ -11,6 +11,7 @@ import type {
   CACResult,
   ROASResult,
   BudgetAllocation,
+  ChannelBudget,
   ChannelCategory,
 } from '../models/marketing/types';
 import {
@@ -132,6 +133,33 @@ export const useMarketingStore = create<MarketingState>((set, get) => ({
         [category]: percent,
       },
     })),
+
+  // Channel-level budgets
+  channelBudgets: [],
+  setChannelBudget: (channelId, budget) =>
+    set((state) => {
+      const { totalBudget, channelBudgets } = state;
+      const percentage = totalBudget > 0 ? (budget / totalBudget) * 100 : 0;
+      const existing = channelBudgets.find((cb) => cb.channel === channelId);
+      if (existing) {
+        return {
+          channelBudgets: channelBudgets.map((cb) =>
+            cb.channel === channelId ? { ...cb, budget, percentage } : cb
+          ),
+        };
+      }
+      return {
+        channelBudgets: [...channelBudgets, { channel: channelId, budget, percentage }],
+      };
+    }),
+  getChannelBudgets: () => {
+    const { channels, totalBudget, channelBudgets } = get();
+    const activeChannels = channels.filter((ch) => ch.isActive);
+    return activeChannels.map((ch) => {
+      const existing = channelBudgets.find((cb) => cb.channel === ch.id);
+      return existing || { channel: ch.id, budget: 0, percentage: 0 };
+    });
+  },
 
   // Current period
   currentPeriod: new Date().toISOString().slice(0, 7),


### PR DESCRIPTION
## Summary
Implements channel-based budget allocation for marketing (Issue #12).

## Changes
- Added `ChannelBudget` type: `{ channel: string, budget: number, percentage: number }`
- Extended marketing store with channel budget state and actions
- Created `BudgetAllocationConfig` component for configuring budgets by channel
- Added route at `/marketing/budget`
- Added quick link from Marketing hub

## Screenshots
N/A (UI component)

Closes #12